### PR TITLE
Remove deprecated methods in HttpGet

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/http/HttpDelete.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HttpDelete.scala
@@ -30,7 +30,7 @@ trait HttpDelete extends HttpVerb with ConnectionTracing with HttpAuditing {
     withTracing(DELETE_VERB, url) {
       val httpResponse = doDelete(url)
       auditRequestWithResponseF(url, DELETE_VERB, None, httpResponse)
-      mapErrors(DELETE_VERB, url, httpResponse).map(handleResponse(url, DELETE_VERB))
+      mapErrors(DELETE_VERB, url, httpResponse).map(handleResponse(DELETE_VERB, url))
     }
   }
 }

--- a/src/main/scala/uk/gov/hmrc/play/http/HttpGet.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HttpGet.scala
@@ -33,29 +33,4 @@ trait HttpGet extends HttpVerb with ConnectionTracing with HttpAuditing {
     auditRequestWithResponseF(url, GET_VERB, None, httpResponse)
     mapErrors(GET_VERB, url, httpResponse).map(response => rds.read(GET_VERB, url, response))
   }
-
-  @deprecated("use GET[HttpResponse] instead, or implement an HttpReads for your type", "23/2/2015")
-  def GET_RawResponse(url:String, fn: HttpResponse => HttpResponse = identity, auditResponseBody: Boolean = true)(implicit hc: HeaderCarrier): Future[HttpResponse] =
-    GET[HttpResponse](url).map(fn)
-
-  /**
-   * The method wraps the response in Option.
-   * For HttpResponse with status 404 or 202, instead of throwing an Exception, None will be returned.
-   */
-  @deprecated("use GET[Option[A]] instead", "23/2/2015")
-  def GET_Optional[A](url: String)(implicit rds: json.Reads[A], mfst: Manifest[A], hc: HeaderCarrier): Future[Option[A]] =
-    GET[Option[A]](url)
-
-  /**
-   * The method extracts the requested collection (array) from JSON response.
-   * arrayFieldName indicates the name of the array field available in the JSON response.
-   * For HttpResponse with status 404 or 202, instead of throwing an Exception, empty Seq is returned.
-   */
-  @deprecated("use GET[Seq[A]] and put a implicit (HttpReads.readJsonFromProperty(arrayFieldName) in scope instead", "23/2/2015")
-  def GET_Collection[A](url: String, arrayFieldName: String)(implicit rds: json.Reads[A], mfst: Manifest[A], hc: HeaderCarrier) : Future[Seq[A]] =
-    GET[Seq[A]](url)(HttpReads.readSeqFromJsonProperty(arrayFieldName), hc)
-
-  @deprecated("moved to HttpReads", "23/2/2015")
-  def readJson[A](url: String, jsValue: JsValue)(implicit rds: json.Reads[A], mf: Manifest[A], hc: HeaderCarrier) =
-    HttpReads.readJson(GET_VERB, url, jsValue)
 }

--- a/src/test/scala/uk/gov/hmrc/play/http/HttpPostSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/http/HttpPostSpec.scala
@@ -27,50 +27,32 @@ import scala.concurrent.Future
 class HttpPostSpec extends WordSpecLike with Matchers with CommonHttpBehaviour {
 
   implicit val hc = HeaderCarrier()
-  class TestPOST(
-                  doPostResult: Future[HttpResponse] = defaultHttpResponse,
-                  doFormPostResult: Future[HttpResponse] = defaultHttpResponse,
-                  doPostStringResult: Future[HttpResponse] = defaultHttpResponse,
-                  doPostEmptyResult: Future[HttpResponse] = defaultHttpResponse) extends HttpPost with ConnectionTracingCapturing with MockAuditing {
-    override def doPost[A](url: String, body: A, headers: Seq[(String,String)])(implicit rds: Writes[A], hc: HeaderCarrier): Future[HttpResponse] = doPostResult
-
-    override def doFormPost(url: String, body: Map[String, Seq[String]])(implicit hc: HeaderCarrier): Future[HttpResponse] = doFormPostResult
-
-    override protected def doPostString(url: String, body: String, headers: Seq[(String, String)])(implicit hc: HeaderCarrier): Future[HttpResponse] = doPostStringResult
-
-    var auditRequestWithResponseF_callCount = 0
-    override protected def auditRequestWithResponseF(url: String, verb:String, body: Option[_], responseToAuditF: Future[HttpResponse])(implicit hc: HeaderCarrier): Unit = {
-      auditRequestWithResponseF_callCount = auditRequestWithResponseF_callCount + 1
-    }
-
-    protected def doEmptyPost[A](url: String)(implicit hc: HeaderCarrier) = doPostEmptyResult
+  class StubbedHttpPost(doPostResult: Future[HttpResponse]) extends HttpPost with ConnectionTracingCapturing with MockAuditing {
+    def doPost[A](url: String, body: A, headers: Seq[(String,String)])(implicit rds: Writes[A], hc: HeaderCarrier) = doPostResult
+    def doFormPost(url: String, body: Map[String, Seq[String]])(implicit hc: HeaderCarrier) = doPostResult
+    def doPostString(url: String, body: String, headers: Seq[(String, String)])(implicit hc: HeaderCarrier) = doPostResult
+    def doEmptyPost[A](url: String)(implicit hc: HeaderCarrier) = doPostResult
   }
 
-  lazy val testPOST = new TestPOST()
+  val url = "http://some.url"
+  val testBody = "test body"
 
-  val someUrl = "http://some.url"
-  "handlePOSTResponse" should {
+  "HttpPost" should {
 
     "return the endpoint's response when the returned status code is in the 2xx range" in {
       (200 to 299).foreach {
         status =>
           val response = new DummyHttpResponse("", status)
 
-          val result = testPOST.handleResponse(POST, someUrl)(response)
-
+          val result = new StubbedHttpPost(response).POST(url, testBody).futureValue
           await(result) shouldBe response
       }
     }
 
-    val testBody = "testBody"
-
     "throw an NotFoundException when the response has 404 status" in {
       val response = new DummyHttpResponse(testBody, 404)
 
-      val url: String = "http://some.nonexistent.url"
-      val e = intercept[NotFoundException] {
-        await(testPOST.handleResponse(POST, url)(response))
-      }
+      val e = new StubbedHttpPost(response).POST(url, testBody).failed.futureValue
 
       e.getMessage should startWith(POST)
       e.getMessage should include(url)
@@ -81,10 +63,7 @@ class HttpPostSpec extends WordSpecLike with Matchers with CommonHttpBehaviour {
     "throw an BadRequestException when the response has 400 status" in {
       val response = new DummyHttpResponse(testBody, 400)
 
-      val url: String = "http://some.nonexistent.url"
-      val e = intercept[BadRequestException] {
-        await(testPOST.handleResponse(POST, url)(response))
-      }
+      val e = new StubbedHttpPost(response).POST(url, testBody).failed.futureValue
 
       e.getMessage should startWith(POST)
       e.getMessage should include(url)
@@ -92,17 +71,13 @@ class HttpPostSpec extends WordSpecLike with Matchers with CommonHttpBehaviour {
       e.getMessage should include(testBody)
     }
 
-    behave like anErrorMappingHttpCall(POST, (url, responseF) => new TestPOST(doPostResult = responseF).POST(url, "anyString"))
-    behave like aTracingHttpCall[TestPOST](POST, "POST", new TestPOST) { _.POST(someUrl, "anyString") }
+    behave like anErrorMappingHttpCall(POST, (url, responseF) => new StubbedHttpPost(responseF).POST(url, "anyString"))
+    behave like aTracingHttpCall[StubbedHttpPost](POST, "POST", new StubbedHttpPost(defaultHttpResponse)) { _.POST(url, "anyString") }
 
     "throw a Exception when the response has an arbitrary status" in {
-      val status = 500
-      val response = new DummyHttpResponse(testBody, status)
+      val response = new DummyHttpResponse(testBody, 500)
 
-      val url: String = "http://some.nonexistent.url"
-      val e = intercept[Exception] {
-        await(testPOST.handleResponse(POST, url)(response))
-      }
+      val e = new StubbedHttpPost(response).POST(url, testBody).failed.futureValue
 
       e.getMessage should startWith(POST)
       e.getMessage should include(url)
@@ -112,18 +87,18 @@ class HttpPostSpec extends WordSpecLike with Matchers with CommonHttpBehaviour {
   }
 
   "POSTForm" should {
-    behave like anErrorMappingHttpCall(POST, (url, responseF) => new TestPOST(doFormPostResult = responseF).POSTForm(url, Map()))
-    behave like aTracingHttpCall[TestPOST](POST, "POSTForm", new TestPOST) { _.POSTForm(someUrl, Map()) }
+    behave like anErrorMappingHttpCall(POST, (url, responseF) => new StubbedHttpPost(responseF).POSTForm(url, Map()))
+    behave like aTracingHttpCall[StubbedHttpPost](POST, "POSTForm", new StubbedHttpPost(defaultHttpResponse)) { _.POSTForm(url, Map()) }
   }
 
   "POSTString"  should {
-    behave like anErrorMappingHttpCall(POST, (url, responseF) => new TestPOST(doPostStringResult = responseF).POSTString(url, "body", Seq.empty))
-    behave like aTracingHttpCall[TestPOST](POST, "POSTString", new TestPOST) { _.POSTString(someUrl, "body", Seq.empty) }
+    behave like anErrorMappingHttpCall(POST, (url, responseF) => new StubbedHttpPost(responseF).POSTString(url, "body", Seq.empty))
+    behave like aTracingHttpCall[StubbedHttpPost](POST, "POSTString", new StubbedHttpPost(defaultHttpResponse)) { _.POSTString(url, "body", Seq.empty) }
   }
 
   "POSTEmpty"  should {
-    behave like anErrorMappingHttpCall(POST, (url, responseF) => new TestPOST(doPostEmptyResult = responseF).POSTEmpty(url))
-    behave like aTracingHttpCall[TestPOST](POST, "POSTEmpty", new TestPOST) { _.POSTEmpty(someUrl) }
+    behave like anErrorMappingHttpCall(POST, (url, responseF) => new StubbedHttpPost(responseF).POSTEmpty(url))
+    behave like aTracingHttpCall[StubbedHttpPost](POST, "POSTEmpty", new StubbedHttpPost(defaultHttpResponse)) { _.POSTEmpty(url) }
   }
 
 }


### PR DESCRIPTION
Also improve testing of the other verbs to directly test the `POST(...)`, `DELETE(...)`, `PUT(...)` methods. In the process I also squashed a bug around error reporting in `HttpDelete`.