### PR TITLE
updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,9 @@ Having an implicit `Reads[A]` for your class in scope allows automatic serialisa
 ## Implementation & Extension
 Response handling is implemented via the `HttpReads[A]` typeclass, which is responsible for converting the raw response into either an exception or the specified type. Default implementations of `HttpReads[A]` have been provided in its companion object to cover common use cases, but clients may provide their own implementations if required. 
 bbb error handling currently applied to all responses (translating `400` to `BadRequestException` etc.) is used in all of these readers. All `GET_*` can now be deprecated - a message has been aded to each explaining what should be used instead.
+
+## Configuration
+```HttpAuditing``` now provides ```def auditDisabledForPattern = ("""http://.*\.service""").r``` which client applications may chose to override when mixing in ```HttpAuditing```.
+
+_NOTE:_ This configuration used to be provided by reading Play configuration property ```<env>.http-client.audit.disabled-for``` which is now obsolete.
+


### PR DESCRIPTION
- added a very brief explanation that this library will no longer read from play config and that the previous config auditDisabledForPattern can still be overridden by clients