### PR TITLE
Add support for HttpReads to POST and PUT

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/http/HttpPost.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HttpPost.scala
@@ -34,11 +34,10 @@ trait HttpPost extends HttpVerb with ConnectionTracing with HttpAuditing {
 
   protected def doFormPost(url: String, body: Map[String, Seq[String]])(implicit hc: HeaderCarrier): Future[HttpResponse]
 
-  private def defaultHandler(implicit hc: HeaderCarrier): ProcessingFunction =
-    (responseF: Future[HttpResponse], url: String) => responseF.map { response => handleResponse(POST_VERB, url)(response)}
-
-  @deprecated("ProcessingFunction is obselete, use the relevant HttpReads[A] instead")
-  def POST[A](url: String, body: A, responseHandler: ProcessingFunction, headers: Seq[(String,String)] = Seq.empty)(implicit rds: Writes[A], hc: HeaderCarrier): Future[HttpResponse] = {
+  @deprecated("ProcessingFunction is obselete, use the relevant HttpReads[A] instead", "18/03/2015")
+  def POST[A](url: String, body: A, responseHandler: ProcessingFunction)(implicit rds: Writes[A], hc: HeaderCarrier): Future[HttpResponse] = POST[A](url, body, responseHandler, Seq())
+  @deprecated("ProcessingFunction is obselete, use the relevant HttpReads[A] instead", "18/03/2015")
+  def POST[A](url: String, body: A, responseHandler: ProcessingFunction, headers: Seq[(String,String)])(implicit rds: Writes[A], hc: HeaderCarrier): Future[HttpResponse] = {
     withTracing(POST_VERB, url) {
       val httpResponse = doPost(url, body, headers)
       auditRequestWithResponseF(url, POST_VERB, Option(Json.stringify(rds.writes(body))), httpResponse)
@@ -46,8 +45,10 @@ trait HttpPost extends HttpVerb with ConnectionTracing with HttpAuditing {
     }
   }
 
-  @deprecated("ProcessingFunction is obselete, use the relevant HttpReads[A] instead")
-  def POSTString(url: String, body: String, responseHandler: ProcessingFunction, headers: Seq[(String,String)] = Seq.empty, auditRequestBody: Boolean = true, auditResponseBody: Boolean = true)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
+  @deprecated("ProcessingFunction is obselete, use the relevant HttpReads[A] instead", "18/03/2015")
+  def POSTString(url: String, body: String, responseHandler: ProcessingFunction)(implicit hc: HeaderCarrier): Future[HttpResponse] = POSTString(url, body, responseHandler)
+  @deprecated("auditRequestBody/auditResponseBody are no longer supported, use PUT(url, body) and configuration instead. ProcessingFunction is obselete, use the relevant HttpReads[A] instead", "18/03/2015")
+  def POSTString(url: String, body: String, responseHandler: ProcessingFunction, headers: Seq[(String,String)], auditRequestBody: Boolean, auditResponseBody: Boolean)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
     withTracing(POST_VERB, url) {
       val httpResponse = doPostString(url, body, headers)
       auditRequestWithResponseF(url, POST_VERB, Option(body), httpResponse)
@@ -55,7 +56,7 @@ trait HttpPost extends HttpVerb with ConnectionTracing with HttpAuditing {
     }
   }
 
-  @deprecated("ProcessingFunction is obselete, use the relevant HttpReads[A] instead")
+  @deprecated("ProcessingFunction is obselete, use the relevant HttpReads[A] instead", "18/03/2015")
   def POSTForm(url: String, body: Map[String, Seq[String]], responseHandler: ProcessingFunction)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
     withTracing(POST_VERB, url) {
       val httpResponse = doFormPost(url, body)

--- a/src/main/scala/uk/gov/hmrc/play/http/HttpPut.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HttpPut.scala
@@ -30,14 +30,20 @@ trait HttpPut extends HttpVerb with ConnectionTracing with HttpAuditing {
 
   private def defaultHandler(responseF: Future[HttpResponse], url: String)(implicit hc: HeaderCarrier): Future[HttpResponse] = responseF.map(handleResponse(PUT_VERB, url))
 
-  def PUT[A](url: String, body: A)(implicit rds: Writes[A], hc: HeaderCarrier): Future[HttpResponse] = {
-    PUT(url, body, defaultHandler)
+  def PUT[I, O](url: String, body: I)(implicit wts: Writes[I], rds: HttpReads[O], hc: HeaderCarrier): Future[O] = {
+    withTracing(PUT_VERB, url) {
+      val httpResponse = doPut(url, body)
+      auditRequestWithResponseF(url, PUT_VERB, Option(Json.stringify(wts.writes(body))), httpResponse)
+      mapErrors(PUT_VERB, url, httpResponse).map(response => rds.read(PUT_VERB, url, response))
+    }
   }
 
+  @deprecated("auditRequestBody/auditResponseBody are no longer supported, use PUT(url, body) and configuration instead")
   def PUT[A](url: String, body: A, auditRequestBody: Boolean, auditResponseBody: Boolean)(implicit rds: Writes[A], hc: HeaderCarrier): Future[HttpResponse] = {
     PUT(url, body, defaultHandler, auditRequestBody, auditResponseBody)
   }
 
+  @deprecated("auditRequestBody/auditResponseBody are no longer supported, use PUT(url, body) and configuration instead. ProcessingFunction is obselete, use the relevant HttpReads[A] instead")
   def PUT[A](url: String, body: A, responseHandler: ProcessingFunction,  auditRequestBody: Boolean = true, auditResponseBody: Boolean = true)(implicit rds: Writes[A], hc: HeaderCarrier): Future[HttpResponse] = {
     withTracing(PUT_VERB, url) {
       val httpResponse = doPut(url, body)

--- a/src/main/scala/uk/gov/hmrc/play/http/HttpPut.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HttpPut.scala
@@ -38,12 +38,12 @@ trait HttpPut extends HttpVerb with ConnectionTracing with HttpAuditing {
     }
   }
 
-  @deprecated("auditRequestBody/auditResponseBody are no longer supported, use PUT(url, body) and configuration instead")
+  @deprecated("auditRequestBody/auditResponseBody are no longer supported, use PUT(url, body) and configuration instead", "18/03/2015")
   def PUT[A](url: String, body: A, auditRequestBody: Boolean, auditResponseBody: Boolean)(implicit rds: Writes[A], hc: HeaderCarrier): Future[HttpResponse] = {
     PUT(url, body, defaultHandler, auditRequestBody, auditResponseBody)
   }
 
-  @deprecated("auditRequestBody/auditResponseBody are no longer supported, use PUT(url, body) and configuration instead. ProcessingFunction is obselete, use the relevant HttpReads[A] instead")
+  @deprecated("auditRequestBody/auditResponseBody are no longer supported, use PUT(url, body) and configuration instead. ProcessingFunction is obselete, use the relevant HttpReads[A] instead", "18/03/2015")
   def PUT[A](url: String, body: A, responseHandler: ProcessingFunction,  auditRequestBody: Boolean = true, auditResponseBody: Boolean = true)(implicit rds: Writes[A], hc: HeaderCarrier): Future[HttpResponse] = {
     withTracing(PUT_VERB, url) {
       val httpResponse = doPut(url, body)

--- a/src/main/scala/uk/gov/hmrc/play/http/HttpVerb.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HttpVerb.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.play.http
 import scala.concurrent.Future
 
 trait HttpVerb extends HttpErrorFunctions {
-
+  @deprecated("ProcessingFunction is obselete, use the relevant HttpReads[A] instead", "18/03/2015")
   type ProcessingFunction = (Future[HttpResponse], String) => Future[HttpResponse]
-
 }

--- a/src/test/scala/uk/gov/hmrc/play/http/CommonHttpBehaviour.scala
+++ b/src/test/scala/uk/gov/hmrc/play/http/CommonHttpBehaviour.scala
@@ -32,8 +32,11 @@ import scala.concurrent.Future
 trait CommonHttpBehaviour extends ScalaFutures with Matchers with WordSpecLike {
 
   case class TestClass(foo: String, bar: Int)
+  implicit val tcreads = Json.format[TestClass]
 
-  implicit val reads = Json.format[TestClass]
+  case class TestRequestClass(baz: String, bar: Int)
+  implicit val trcreads = Json.format[TestRequestClass]
+
   implicit val hc = HeaderCarrier()
   val testBody = "testBody"
   val testRequestBody = "testRequestBody"

--- a/src/test/scala/uk/gov/hmrc/play/http/CommonHttpBehaviour.scala
+++ b/src/test/scala/uk/gov/hmrc/play/http/CommonHttpBehaviour.scala
@@ -36,6 +36,7 @@ trait CommonHttpBehaviour extends ScalaFutures with Matchers with WordSpecLike {
   implicit val reads = Json.format[TestClass]
   implicit val hc = HeaderCarrier()
   val testBody = "testBody"
+  val testRequestBody = "testRequestBody"
   val url = "http://some.url"
 
   def response(returnValue: Option[String] = None, statusCode: Int = 200) = Future.successful(HttpResponse(statusCode, returnValue.map(Json.parse(_))))

--- a/src/test/scala/uk/gov/hmrc/play/http/HttpErrorFunctionsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/http/HttpErrorFunctionsSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.play.http
 
 import org.scalacheck.Gen

--- a/src/test/scala/uk/gov/hmrc/play/http/HttpPutSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/http/HttpPutSpec.scala
@@ -32,21 +32,22 @@ class HttpPutSpec extends WordSpecLike with Matchers with CommonHttpBehaviour {
   }
 
   "HttpPut" should {
+    val testObject = TestRequestClass("a", 1)
     "be able to return plain responses" in {
       val response = new DummyHttpResponse(testBody, 200)
       val testPut = new StubbedHttpPut(Future.successful(response))
-      testPut.PUT(url, testRequestBody).futureValue shouldBe response
+      testPut.PUT(url, testObject).futureValue shouldBe response
     }
     "be able to return HTML responses" in new HtmlHttpReads {
       val testPut = new StubbedHttpPut(Future.successful(new DummyHttpResponse(testBody, 200)))
-      testPut.PUT(url, testRequestBody).futureValue should be (an [Html])
+      testPut.PUT(url, testObject).futureValue should be (an [Html])
     }
     "be able to return objects deserialised from JSON" in {
       val testPut = new StubbedHttpPut(Future.successful(new DummyHttpResponse("""{"foo":"t","bar":10}""", 200)))
-      testPut.PUT[String, TestClass](url, testRequestBody).futureValue should be (TestClass("t", 10))
+      testPut.PUT[TestRequestClass, TestClass](url, testObject).futureValue should be (TestClass("t", 10))
     }
 
-    behave like anErrorMappingHttpCall(PUT, (url, responseF) => new StubbedHttpPut(responseF).PUT(url, testRequestBody))
-    behave like aTracingHttpCall(PUT, "PUT", new StubbedHttpPut(defaultHttpResponse)) { _.PUT(url, testRequestBody) }
+    behave like anErrorMappingHttpCall(PUT, (url, responseF) => new StubbedHttpPut(responseF).PUT(url, testObject))
+    behave like aTracingHttpCall(PUT, "PUT", new StubbedHttpPut(defaultHttpResponse)) { _.PUT(url, testObject) }
   }
 }

--- a/src/test/scala/uk/gov/hmrc/play/http/HttpPutSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/http/HttpPutSpec.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.play.http
 import org.scalatest.{Matchers, WordSpecLike}
 import play.api.http.HttpVerbs._
 import play.api.libs.json.Writes
+import play.twirl.api.Html
 import uk.gov.hmrc.play.audit.http.HeaderCarrier
 import uk.gov.hmrc.play.test.Concurrent.await
 import uk.gov.hmrc.play.test.Concurrent.liftFuture
@@ -29,56 +30,23 @@ class HttpPutSpec extends WordSpecLike with Matchers with CommonHttpBehaviour {
   class StubbedHttpPut(doPutResult: Future[HttpResponse]) extends HttpPut with ConnectionTracingCapturing with MockAuditing {
     def doPut[A](url: String, body: A)(implicit rds: Writes[A], hc: HeaderCarrier)= doPutResult
   }
-  
+
   "HttpPut" should {
-
-    val testBody = "testBody"
-    val url = "http://some.nonexistent.url"
-
-    "return the endpoint's response when the returned status code is in the 2xx range" in {
-      (200 to 299).foreach { status =>
-        val response = new DummyHttpResponse(testBody, status)
-        val result = new StubbedHttpPut(response).PUT("http://some.url", testBody).futureValue
-        result shouldBe response
-      }
+    "be able to return plain responses" in {
+      val response = new DummyHttpResponse(testBody, 200)
+      val testPut = new StubbedHttpPut(Future.successful(response))
+      testPut.PUT(url, testRequestBody).futureValue shouldBe response
+    }
+    "be able to return HTML responses" in new HtmlHttpReads {
+      val testPut = new StubbedHttpPut(Future.successful(new DummyHttpResponse(testBody, 200)))
+      testPut.PUT(url, testRequestBody).futureValue should be (an [Html])
+    }
+    "be able to return objects deserialised from JSON" in {
+      val testPut = new StubbedHttpPut(Future.successful(new DummyHttpResponse("""{"foo":"t","bar":10}""", 200)))
+      testPut.PUT[String, TestClass](url, testRequestBody).futureValue should be (TestClass("t", 10))
     }
 
-    "throw an NotFoundException when the response has 404 status" in {
-      val response = new DummyHttpResponse(testBody, 404)
-
-      val e = new StubbedHttpPut(response).PUT(url, testBody).failed.futureValue
-
-      e.getMessage should startWith(PUT)
-      e.getMessage should include(url)
-      e.getMessage should include("404")
-      e.getMessage should include(testBody)
-      e.getMessage should include(testBody)
-    }
-
-    "throw an BadRequestException when the response has 400 status" in {
-      val response = new DummyHttpResponse(testBody, 400)
-
-      val e = new StubbedHttpPut(response).PUT(url, testBody).failed.futureValue
-
-      e.getMessage should startWith(PUT)
-      e.getMessage should include(url)
-      e.getMessage should include("400")
-      e.getMessage should include(testBody)
-    }
-
-    behave like anErrorMappingHttpCall(PUT, (url, responseF) => new StubbedHttpPut(responseF).PUT[String](url, "testString"))
-    behave like aTracingHttpCall(PUT, "PUT", new StubbedHttpPut(defaultHttpResponse)) { _.PUT[String]("http://some.url", "body")}
-
-    "throw a Exception when the response has an arbitrary status" in {
-      val status = 500
-      val response = new DummyHttpResponse(testBody, status)
-
-      val e = new StubbedHttpPut(response).PUT(url, testBody).failed.futureValue
-
-      e.getMessage should startWith(PUT)
-      e.getMessage should include(url)
-      e.getMessage should include("500")
-      e.getMessage should include(testBody)
-    }
+    behave like anErrorMappingHttpCall(PUT, (url, responseF) => new StubbedHttpPut(responseF).PUT(url, testRequestBody))
+    behave like aTracingHttpCall(PUT, "PUT", new StubbedHttpPut(defaultHttpResponse)) { _.PUT(url, testRequestBody) }
   }
 }

--- a/src/test/scala/uk/gov/hmrc/play/http/HttpReadsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/http/HttpReadsSpec.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package uk.gov.hmrc.play.http
 


### PR DESCRIPTION
This completes the transition from partial support of the `ProcessingFunction` to using `HttpReads[A]` across all verbs. `ProcessingFunction` has been deprecated, and where possible the old methods that supported it have been left in place but deprecated.

There is a quite a lot of duplication in `HttpPost` because of the all of the variants of request type it supports and that you can only have one method with default arguments. I think it's backwards-compatible, apart from the removal of the `auditRequestBody` and `auditResponseBody` parameters which seem to not be used anyway.  It would be helpful if someone could review to see if I've missed anything.