### PR TITLE
Improving travis performances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 sudo: false
 language: scala
 scala:
-- 2.11.5
 - 2.11.6
 jdk:
 - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
+# Use docker-based build environment (instead of openvz)
+sudo: false
 language: scala
 scala:
 - 2.11.5
 - 2.11.6
 jdk:
 - oraclejdk7
+
+cache:
+  directories:
+    - '$HOME/.m2/repository'
+    - '$HOME/.ivy2/cache'
+
 #branches:
 #  only:
 #  - master


### PR DESCRIPTION
We can speed up the builds on travis by:
- using docker-based build environment (instead of openvz)
- cache the sbt dependencies