### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,15 @@ object ConnectorWithHttpValues extends ConnectorWithHttpValues {
 }
 ```
 
-In both cases, you'll need to supply an [auditing configuration](#Configuration). 
+In both cases, you'll need to supply an [auditing configuration](#configuration). 
 
 #### Making HTTP Calls
 
 Each verb supplies a single matching method, which takes a URL, and a request body if appropriate:
 
 ```scala
+implicit val hc = HeaderCarrier()
+
 http.GET("http://gov.uk/hmrc")
 http.DELETE("http://gov.uk/hmrc")
 http.POST("http://gov.uk/hmrc", body = "hi there")
@@ -99,7 +101,7 @@ httpGet.GET("url") recover {
 }
 ```
 
-or special [response readers]() are available.
+or if you expect responses which indicate no content, you can use an [`Option[...]` return type](#potentially-empty-responses).
 
 ### Response Types
 
@@ -139,9 +141,9 @@ r1.body
 r1.allHeaders
 ```
 
-<!--- How to influence which implicit is used - mixin vs import vs directly by type --->
+<!--- TODO: How to influence which implicit is used - mixin vs import vs directly by type --->
 
-<!--- _Talk about special methods in POST_ --->
+<!--- TODO: Talk about special methods POSTString, POSTForm etc. --->
 
 ## Extension & Customisation
 Response handling is implemented via the `HttpReads[A]` typeclass, which is responsible for converting the raw response into either an exception or the specified type. Default implementations of `HttpReads[A]` have been provided in its companion object to cover common use cases, but clients may provide their own implementations if required. 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 http-verbs
 ==========
 
-[![Join the chat at https://gitter.im/hmrc/http-verbs](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/hmrc/http-verbs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
-[![Build Status](https://travis-ci.org/hmrc/http-verbs.svg)](https://travis-ci.org/hmrc/http-verbs)
+[![Build Status](https://travis-ci.org/hmrc/http-verbs.svg)](https://travis-ci.org/hmrc/http-verbs) [![Join the chat at https://gitter.im/hmrc/http-verbs](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/hmrc/http-verbs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 http-verbs is a Scala library providing an interface to make asynchronous HTTP calls.  The underlying implementation uses [Play WS](https://www.playframework.com/documentation/latest/ScalaWS).
 
@@ -15,9 +13,9 @@ It encapsulates some common concerns for calling other HTTP services on the HMRC
 * Response handling, converting failure status codes into a consistent set of exceptions - allows failures to be automatically propagated to the caller
 * Request & Response de-serialization
 
-## Adding to your service
+## Adding to your build
 
-Include the following dependency in your SBT build
+In your SBT build add:
 
 ```scala
 resolvers += Resolver.bintrayRepo("hmrc", "releases")
@@ -25,39 +23,63 @@ resolvers += Resolver.bintrayRepo("hmrc", "releases")
 libraryDependencies += "uk.gov.hmrc" %% "http-verbs" % "1.3.0"
 ```
 
-Request auditing is provided for all HTTP requests that are made using this library. Each request/response pair results in an audit message being created and sent to an external auditing service for processing.  To configure this service, your Play configuration file needs to include:
+## Usage
 
-```javascript
-Prod {
-  auditing {
-    enabled = true
-    traceRequests = true
-    consumer {
-      baseUri {
-        host = <auditing host name>
-        port = <auditing host port>
-      }
-    }
+_All examples show below are available in [Examples.scala](src/test/scala/uk/gov/hmrc/play/Examples.scala)_
+
+#### Adding to your app
+
+Each verb is available as both an agnostic `Http___` trait and a play-specific `WS___` trait. They can be used as mixins:
+
+```scala
+trait ConnectorWithMixins extends HttpGet with HttpPost
+object ConnectorWithMixins extends ConnectorWithMixins with WSGet with WSPost {
+  val appName = "my-app-name"
+  val auditConnector = AuditConnector(LoadAuditingConfig(key = "auditing"))
+}
+```
+
+or as `val`s:
+
+```scala
+trait ConnectorWithHttpValues {
+  val http: HttpGet with HttpPost
+}
+object ConnectorWithHttpValues extends ConnectorWithHttpValues {
+  val http = new WSGet with WSPost {
+    val appName = "my-app-name"
+    val auditConnector = AuditConnector(LoadAuditingConfig(key = "auditing"))
   }
 }
 ```
 
-## Usage
+In both cases, you'll need to supply an [auditing configuration](#Configuration). 
 
-All calls require an implicit `HeaderCarrier` to be in scope. HTTP headers in this class are added every request made, which allows for common headers to be set on all requests; principally to allow for headers to be propagate from an initiating request.
+#### Making HTTP Calls
 
-### HTTP GET
+Each verb supplies a single matching method, which takes a URL, and a request body if appropriate:
 
-Create a HTTP GET client:
 ```scala
-  val httpGet = new WSGet {
-    override def appName = "my-app-name"
-    override def auditConnector = new Auditing {
-      override def auditingConfig = LoadAuditingConfig(s"Prod.auditing")
-    }
-  }
+http.GET("http://gov.uk/hmrc")
+http.DELETE("http://gov.uk/hmrc")
+http.POST("http://gov.uk/hmrc", body = "hi there")
+http.PUT("http://gov.uk/hmrc", body = "hi there")
 ```
-Responses can be returned in many formats. In all cases, responses statuses which indicate errors are converted to failed `Future`s with typed exceptions. This allows failures to be propagated back to the original requestor.
+
+All calls require an implicit `HeaderCarrier`. 
+
+Headers from the carrier are added to every request. Depending on how you scope your implicits, this could allow:
+
+* Common headers to be configured for all requests
+* Headers from an inbound call to be propagated to an outbound one (we do this by implicitly converting Play's `Request` into a `HeaderCarrier`)
+
+## Response Handling
+
+By default, all verbs return `HttpResponse` for successful responses, and exceptions for failures, but this can be customised. 
+
+### Errors
+
+To make microservice development simple, responses with non-200 status codes will cause a failed `Future` to be returned with a typed exception. This allows failures to be propagated back naturally. 
 
 Status Code   | Exception
 ------------- | -------------
@@ -66,17 +88,22 @@ Status Code   | Exception
 4xx           | `Upstream4xxResponse`
 5xx           | `Upstream5xxResponse`
 
-If some failure status codes are expected in normal flow, then special response readers are available, or the returned future can be recovered: 
+_For all possible exception types, see the #hmrc/http-exceptions project_
+
+If some failure status codes are expected in normal flow, `recover` can be used: 
+
 ```scala
-  httpGet.GET[MyCaseClass]("url") map {
-    response =>
-      //success
-  } recover {
-    case notFound: NotFoundException => {}
-    case serverError: Upstream5xxResponse => {}
-  }
+httpGet.GET("url") recover {
+  case nf: NotFoundException => ...
+  case se: Upstream5xxResponse => ...
+}
 ```
 
+or special [response readers]() are available.
+
+### Response Types
+
+http-verbs can automatically map responses into richer types.
 
 #### JSON responses
 In most cases, where JSON is used, having an implicit `play.api.libs.json.Reads[A]` for your class in scope allows automatic de-serialisation to occur.
@@ -102,7 +129,8 @@ If you expect to receive a `204` or `404` response in some circumstances, then y
 ```
 
 #### Plain HTTP response
-If access to the status code, raw body and headers are required without de-serialisation, the `HttpResponse` type can be used
+If access to the status code, raw body and headers are required without de-serialisation, the `HttpResponse` type can be used:
+
 ```scala
   val response = httpGet.GET[HttpResponse](url) // Returns the Http Response
   response.status
@@ -110,32 +138,33 @@ If access to the status code, raw body and headers are required without de-seria
   response.allHeaders
 ```
 
-### HTTP POST
-Create a HTTP POST client:
+<!--- How to influence which implicit is used - mixin vs import vs directly by type --->
 
-```scala
-  val httpPost = new WSPost {
-    override def appName: String = "my-app"
-    override def auditConnector: Auditing = new Auditing {
-      override def auditingConfig: AuditingConfig = LoadAuditingConfig(s"Prod.auditing")
-    }
-  }
-```
+<!--- _Talk about HTTP Readers & Error Handling in detail_ --->
 
-#### JSON requests
-Having an implicit `Reads[A]` for your class in scope allows automatic serialisation to occur.  Headers can be provided as a sequence of string tuples.
-```scala
-  implicit val f = Json.reads[MyCaseClass]
-  val postBody = MyCaseClass("user", 10)
-  httpPost.doPost(url, postBody, headers)
-```
+<!--- _Talk about special methods in POST_ --->
 
-## Implementation & Extension
+## Extension & Customisation
 Response handling is implemented via the `HttpReads[A]` typeclass, which is responsible for converting the raw response into either an exception or the specified type. Default implementations of `HttpReads[A]` have been provided in its companion object to cover common use cases, but clients may provide their own implementations if required. 
-bbb error handling currently applied to all responses (translating `400` to `BadRequestException` etc.) is used in all of these readers. All `GET_*` can now be deprecated - a message has been aded to each explaining what should be used instead.
 
 ## Configuration
-```HttpAuditing``` now provides ```def auditDisabledForPattern = ("""http://.*\.service""").r``` which client applications may chose to override when mixing in ```HttpAuditing```.
+
+Request auditing is provided for all HTTP requests that are made using this library. Each request/response pair results in an audit message being created and sent to an external auditing service for processing.  To configure this service, your Play configuration file needs to include:
+
+```javascript
+auditing {
+  enabled = true
+  traceRequests = true
+  consumer {
+    baseUri {
+      host = ...
+      port = ...
+    }
+  }
+}
+```
+
+```HttpAuditing``` provides ```def auditDisabledForPattern = ("""http://.*\.service""").r``` which client applications may chose to override when mixing in ```HttpAuditing```.
 
 _NOTE:_ This configuration used to be provided by reading Play configuration property ```<env>.http-client.audit.disabled-for``` which is now obsolete.
 

--- a/README.md
+++ b/README.md
@@ -105,42 +105,41 @@ or special [response readers]() are available.
 
 http-verbs can automatically map responses into richer types.
 
-#### JSON responses
-In most cases, where JSON is used, having an implicit `play.api.libs.json.Reads[A]` for your class in scope allows automatic de-serialisation to occur.
+##### JSON responses
+If you have an implicit `play.api.libs.json.Reads[A]` for your type in scope, just specify that type and it will be automatically deserialised.
 
 ```scala
-  implicit val f = Json.reads[MyCaseClass]
-  httpGet.GET[MyCaseClass](url) // Returns an MyCaseClass de-serialised from JSON
+implicit val f = Json.reads[MyCaseClass]
+httpGet.GET[MyCaseClass](url) // Returns an MyCaseClass de-serialised from JSON
 ```
 
-#### HTML responses
-For HTML responses, Play's `Html` type can be used:
+##### HTML responses
+If you wish to use HTML responses, Play's `Html` type can be used:
+
 ```scala                                      
-  httpGet.GET[Html](url) // Returns a Play Html type
+httpGet.GET[Html](url) // Returns a Play Html type
 ```
 
 #### Potentially empty responses
 If you expect to receive a `204` or `404` response in some circumstances, then you can add `Option[...]` to your return type:
 
 ```scala
-  httpGet.GET[Option[MyCaseClass]](url) // Returns a None, or Some[MyCaseClass] de-serialised from JSON
-  httpGet.GET[Option[Html]](url) // Returns a None, or a Play Html type
-
+httpGet.GET[Option[MyCaseClass]](url) // Returns None, or Some[MyCaseClass] de-serialised from JSON
+httpGet.GET[Option[Html]](url) // Returns a None, or a Play Html type
 ```
 
 #### Plain HTTP response
 If access to the status code, raw body and headers are required without de-serialisation, the `HttpResponse` type can be used:
 
 ```scala
-  val response = httpGet.GET[HttpResponse](url) // Returns the Http Response
-  response.status
-  response.body
-  response.allHeaders
+val r1 = httpGet.GET[HttpResponse](url) // Returns the Http Response
+val r2 = httpGet.GET(url) // Also returns the Http Response
+r1.status
+r1.body
+r1.allHeaders
 ```
 
 <!--- How to influence which implicit is used - mixin vs import vs directly by type --->
-
-<!--- _Talk about HTTP Readers & Error Handling in detail_ --->
 
 <!--- _Talk about special methods in POST_ --->
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Status Code   | Exception
 4xx           | `Upstream4xxResponse`
 5xx           | `Upstream5xxResponse`
 
-_For all possible exception types, see the #hmrc/http-exceptions project_
+_For all possible exception types, see the [hmrc/http-exceptions](https://github.com/hmrc/http-exceptions) project_
 
 If some failure status codes are expected in normal flow, `recover` can be used: 
 

--- a/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnector.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/http/connector/AuditConnector.scala
@@ -99,3 +99,6 @@ trait AuditConnector extends Connector with AuditEventFailureKeys with Connectio
     else None
   }
 }
+object AuditConnector {
+  def apply(config: AuditingConfig) = new AuditConnector { def auditingConfig = config }
+}

--- a/src/test/scala/uk/gov/hmrc/play/Examples.scala
+++ b/src/test/scala/uk/gov/hmrc/play/Examples.scala
@@ -1,5 +1,6 @@
 package uk.gov.hmrc.play
 
+import uk.gov.hmrc.play.audit.http.HeaderCarrier
 
 
 object Examples {
@@ -28,11 +29,11 @@ object Examples {
   trait VerbExamples {
     val http: HttpGet with HttpPost with HttpPut with HttpDelete
 
+    implicit val hc = HeaderCarrier()
+
     http.GET("http://gov.uk/hmrc")
     http.DELETE("http://gov.uk/hmrc")
     http.POST("http://gov.uk/hmrc", body = "hi there")
     http.PUT("http://gov.uk/hmrc", body = "hi there")
-
-
   }
 }

--- a/src/test/scala/uk/gov/hmrc/play/Examples.scala
+++ b/src/test/scala/uk/gov/hmrc/play/Examples.scala
@@ -1,0 +1,38 @@
+package uk.gov.hmrc.play
+
+
+
+object Examples {
+
+  import uk.gov.hmrc.play.http._
+  import ws._
+  import audit.http.config._
+  import audit.http.connector._
+
+  trait ConnectorWithHttpValues {
+    val http: HttpGet with HttpPost
+  }
+  object ConnectorWithHttpValues extends ConnectorWithHttpValues {
+    val http = new WSGet with WSPost {
+      val appName = "my-app-name"
+      val auditConnector = AuditConnector(LoadAuditingConfig(key = "auditing"))
+    }
+  }
+
+  trait ConnectorWithMixins extends HttpGet with HttpPost
+  object ConnectorWithMixins extends ConnectorWithMixins with WSGet with WSPost {
+    val appName = "my-app-name"
+    val auditConnector = AuditConnector(LoadAuditingConfig(key = "auditing"))
+  }
+
+  trait VerbExamples {
+    val http: HttpGet with HttpPost with HttpPut with HttpDelete
+
+    http.GET("http://gov.uk/hmrc")
+    http.DELETE("http://gov.uk/hmrc")
+    http.POST("http://gov.uk/hmrc", body = "hi there")
+    http.PUT("http://gov.uk/hmrc", body = "hi there")
+
+
+  }
+}


### PR DESCRIPTION
I've reworked the README following the changes to use `HttpReads` in all verbs. I've tried to make it a bit more tutorial like for someone that's not used the library before. I've also fixed a few mistakes and added a matching `Examples.scala`.