### PR TITLE
YTA-779 fixed auditing for microservices (AuditFilter) to retrieve all a...

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/audit/filters/FrontendAuditFilter.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/filters/FrontendAuditFilter.scala
@@ -30,9 +30,11 @@ trait FrontendAuditFilter extends AuditFilter {
 
   def applicationPort: Option[Int]
 
+  override def buildAuditedHeaders(request: RequestHeader) = HeaderCarrier.fromSessionAndHeaders(request.session, request.headers)
+
   override def buildAuditRequestEvent(eventType: EventTypes.EventType, request: RequestHeader, requestBody: String)(implicit hc: HeaderCarrier): DataEvent = {
 
-    super.buildAuditRequestEvent(eventType, request, stripPasswords(request.contentType, requestBody, maskedFormFields))(HeaderCarrier.fromSessionAndHeaders(request.session, request.headers))
+    super.buildAuditRequestEvent(eventType, request, stripPasswords(request.contentType, requestBody, maskedFormFields))
       .withDetail(buildRequestDetails(request).toSeq: _*)
   }
 

--- a/src/test/scala/uk/gov/hmrc/play/audit/filters/FilterFlowMock.scala
+++ b/src/test/scala/uk/gov/hmrc/play/audit/filters/FilterFlowMock.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.audit.filters
+
+import play.api.libs.iteratee.Iteratee
+import play.api.mvc.{EssentialAction, Results, Result, RequestHeader}
+
+import scala.concurrent.ExecutionContext
+
+trait FilterFlowMock {
+
+  def action(implicit ec: ExecutionContext) : (RequestHeader) => Iteratee[Array[Byte], Result] = { requestHeader =>
+    Iteratee.fold[Array[Byte], Result](new Results.Status(404)) {
+      (length, bytes) => new Results.Status(200)
+    }
+  }
+
+  def nextAction(implicit ec: ExecutionContext) = EssentialAction(action)
+
+
+}


### PR DESCRIPTION
...udit data from headers, not session (as there is no session available).

FrontendAuditFilter will still get some of the data from the session.