### PR TITLE
Make Option verb return types... optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,18 @@ http.GET[Html]("http://gov.uk/hmrc") // Returns a Play Html type
 ```
 
 #### Potentially empty responses
-If you expect to receive a `204` or `404` response in some circumstances, then you can add `Option[...]` to your return type:
+If you expect to receive a `204` or `404` response in some circumstances, then http-verbs supports an `Option[...]` on your return type. You'll need to mix-in or import `OptionHttpReads`:
 
 ```scala
-http.GET[Option[MyCaseClass]]("http://gov.uk/hmrc") // Returns None, or Some[MyCaseClass] de-serialised from JSON
+
+object MyConnector extends OptionHttpReads {
+  http.GET[Option[Html]]("http://gov.uk/hmrc") // Returns a None, or a Play Html type
+  http.GET[Option[MyCaseClass]]("http://gov.uk/hmrc") // Returns None, or Some[MyCaseClass] de-serialised from JSON
+}
+
+import OptionHttpReads._
 http.GET[Option[Html]]("http://gov.uk/hmrc") // Returns a None, or a Play Html type
+http.GET[Option[MyCaseClass]]("http://gov.uk/hmrc") // Returns None, or Some[MyCaseClass] de-serialised from JSON
 ```
 
 <!--- TODO: How to influence which implicit is used - mixin vs import vs directly by type --->

--- a/src/main/scala/uk/gov/hmrc/play/http/HttpReads.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HttpReads.scala
@@ -24,7 +24,7 @@ trait HttpReads[O] {
   def read(method: String, url: String, response: HttpResponse): O
 }
 
-object HttpReads extends HtmlHttpReads with OptionHttpReads with JsonHttpReads {
+object HttpReads extends HtmlHttpReads with JsonHttpReads {
   // readRaw is brought in like this rather than in a trait as this gives it
   // compilation priority during implicit resolution. This means, unless
   // specified otherwise a verb call will return a plain HttpResponse
@@ -46,6 +46,7 @@ trait OptionHttpReads extends HttpErrorFunctions {
     }
   }
 }
+object OptionHttpReads extends OptionHttpReads
 
 trait HtmlHttpReads extends HttpErrorFunctions {
   implicit val readToHtml: HttpReads[Html] = new HttpReads[Html] {

--- a/src/test/scala/uk/gov/hmrc/play/Examples.scala
+++ b/src/test/scala/uk/gov/hmrc/play/Examples.scala
@@ -70,7 +70,13 @@ object Examples {
     import play.twirl.api.Html
     http.GET[Html]("http://gov.uk/hmrc") // Returns a Play Html type
 
-    http.GET[Option[MyCaseClass]]("http://gov.uk/hmrc") // Returns None, or Some[MyCaseClass] de-serialised from JSON
+    object ExampleWithOptionReadsAsMixin extends OptionHttpReads {
+      http.GET[Option[Html]]("http://gov.uk/hmrc") // Returns a None, or a Play Html type
+      http.GET[Option[MyCaseClass]]("http://gov.uk/hmrc") // Returns None, or Some[MyCaseClass] de-serialised from JSON
+    }
+
+    import OptionHttpReads._
     http.GET[Option[Html]]("http://gov.uk/hmrc") // Returns a None, or a Play Html type
+    http.GET[Option[MyCaseClass]]("http://gov.uk/hmrc") // Returns None, or Some[MyCaseClass] de-serialised from JSON
   }
 }


### PR DESCRIPTION
The support for option return types from verbs ie: 

`http.GET[Option[...]](url)`

seems to be causing some confusion. Also, to keep backwards-compatibility with the deleted `GET_Optional`, it returns `None` on both 204 and 404 status codes. 

So, for the moment, I propose to just make it a feature that you have to explicitly enable. Have updated the README to show how. If you specify an `Option` return type without bringing in the reads, then you should get a compile error. I've got a further change brewing that will add more configurability for reads in general.