### PR TITLE
Adding streaming responses to http-verbs

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/http/HttpErrorFunctions.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HttpErrorFunctions.scala
@@ -71,4 +71,20 @@ protected[http] trait HttpErrorFunctions {
       case e: TimeoutException => throw new GatewayTimeoutException(gatewayTimeoutMessage(httpMethod, url, e))
       case e: ConnectException => throw new BadGatewayException(badGatewayMessage(httpMethod, url, e))
     }
+
+  def handleStreamedResponse(httpMethod: String, url: String)(response: StreamingHttpResponse) =
+    response.status match {
+      case status if is2xx(status) => response
+      case 400 => throw new BadRequestException(badRequestMessage(httpMethod, url, response.body))
+      case 404 => throw new NotFoundException(notFoundMessage(httpMethod, url, response.body))
+      case status if is4xx(status) => throw new Upstream4xxResponse(upstreamResponseMessage(httpMethod, url, status, response.body), status, 500, response.allHeaders)
+      case status if is5xx(status) => throw new Upstream5xxResponse(upstreamResponseMessage(httpMethod, url, status, response.body), status, 502)
+      case status => throw new Exception(s"$httpMethod to $url failed with status $status. Response body: '${response.body}'")
+    }
+
+  def mapStreamedErrors(httpMethod: String, url: String, f: Future[StreamingHttpResponse])(implicit ec: ExecutionContext): Future[StreamingHttpResponse] =
+    f.recover {
+      case e: TimeoutException => throw new GatewayTimeoutException(gatewayTimeoutMessage(httpMethod, url, e))
+      case e: ConnectException => throw new BadGatewayException(badGatewayMessage(httpMethod, url, e))
+    }
 }

--- a/src/main/scala/uk/gov/hmrc/play/http/HttpResponse.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HttpResponse.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.play.http
 
+import play.api.libs.iteratee.Enumerator
 import play.api.libs.json.{Json, JsValue}
 import play.api.mvc.Headers
 
@@ -42,6 +43,16 @@ object HttpResponse {
     override def allHeaders: Map[String, Seq[String]] = responseHeaders
     override def body: String = responseString orElse responseJson.map(Json.prettyPrint) orNull
     override def json: JsValue = responseJson.orNull
+    override def status: Int = responseStatus
+  }
+}
+
+trait StreamingHttpResponse extends HttpResponse {
+  def bodyEnumerator: Enumerator[Array[Byte]] = ???
+}
+
+object StreamingHttpResponse {
+  def apply(responseStatus: Int) = new StreamingHttpResponse {
     override def status: Int = responseStatus
   }
 }

--- a/src/main/scala/uk/gov/hmrc/play/http/ws/WSHttpResponse.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/ws/WSHttpResponse.scala
@@ -16,8 +16,10 @@
 
 package uk.gov.hmrc.play.http.ws
 
-import play.api.libs.ws.WSResponse
-import uk.gov.hmrc.play.http.HttpResponse
+import play.api.libs.iteratee.Enumerator
+import play.api.libs.json.Json
+import play.api.libs.ws.{WSResponseHeaders, WSResponse}
+import uk.gov.hmrc.play.http.{StreamingHttpResponse, HttpResponse}
 
 class WSHttpResponse(wsResponse: WSResponse) extends HttpResponse {
   override def allHeaders: Map[String, Seq[String]] = wsResponse.allHeaders
@@ -27,6 +29,18 @@ class WSHttpResponse(wsResponse: WSResponse) extends HttpResponse {
   override def json = wsResponse.json
 
   override def body = wsResponse.body
+}
+
+class WSStreamingHttpResponse(wsResponse: WSResponseHeaders, wsBody: Enumerator[Array[Byte]]) extends StreamingHttpResponse {
+  override def allHeaders: Map[String, Seq[String]] = wsResponse.headers
+
+  override def status = wsResponse.status
+
+  override def json = Json.toJson("...enumerated body...")
+
+  override def body = "...enumerated body..."
+
+  override def bodyEnumerator = wsBody
 }
 
 trait WSHttp extends WSGet with WSPut with WSPost with WSDelete

--- a/src/main/scala/uk/gov/hmrc/play/http/ws/WSPost.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/ws/WSPost.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.play.http.ws
 import play.api.libs.json.{Json, Writes}
 import uk.gov.hmrc.play.audit.http.HeaderCarrier
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext
-import uk.gov.hmrc.play.http.{HttpPost, HttpResponse}
+import uk.gov.hmrc.play.http.{StreamingHttpResponse, HttpPost, HttpResponse}
 import MdcLoggingExecutionContext._
 
 import scala.concurrent.Future
@@ -45,4 +45,7 @@ trait WSPost extends HttpPost with WSRequest {
     buildRequest(url).post(Results.EmptyContent()).map(new WSHttpResponse(_))
   }
 
+  override def doPostAndRetrieveStream[I](url: String, body: I, headers: Seq[(String, String)])(implicit wts: Writes[I], hc: HeaderCarrier): Future[StreamingHttpResponse] = {
+    buildRequest(url).withHeaders(headers: _*).withMethod("POST").withBody(Json.toJson(body)).stream().map( response => new WSStreamingHttpResponse( response._1, response._2 ) )
+  }
 }

--- a/src/test/scala/uk/gov/hmrc/play/http/DummyHttpResponse.scala
+++ b/src/test/scala/uk/gov/hmrc/play/http/DummyHttpResponse.scala
@@ -16,8 +16,15 @@
 
 package uk.gov.hmrc.play.http
 
+import play.api.libs.iteratee.Enumerator
 import play.api.libs.json.{JsValue, Json}
 
 class DummyHttpResponse(override val body: String, override val status: Int, override val allHeaders: Map[String, Seq[String]] = Map.empty) extends HttpResponse {
   override def json: JsValue = Json.parse(body)
+}
+
+class DummyStreamingHttpResponse(override val body: String, override val status: Int, override val allHeaders: Map[String, Seq[String]] = Map.empty) extends StreamingHttpResponse {
+  override def json: JsValue = Json.parse(body)
+
+  override def bodyEnumerator: Enumerator[Array[Byte]] = Enumerator[Array[Byte]]("This should be a stream".getBytes())
 }

--- a/src/test/scala/uk/gov/hmrc/play/http/HttpPostSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/http/HttpPostSpec.scala
@@ -32,6 +32,7 @@ class HttpPostSpec extends WordSpecLike with Matchers with CommonHttpBehaviour {
     def doFormPost(url: String, body: Map[String, Seq[String]])(implicit hc: HeaderCarrier) = doPostResult
     def doPostString(url: String, body: String, headers: Seq[(String, String)])(implicit hc: HeaderCarrier) = doPostResult
     def doEmptyPost[A](url: String)(implicit hc: HeaderCarrier) = doPostResult
+    def doPostAndRetrieveStream[I](url: String, body: I, headers: Seq[(String, String)])(implicit wts: Writes[I], hc: HeaderCarrier): Future[StreamingHttpResponse] = ???
   }
 
   "HttpPost.POST" should {

--- a/src/test/scala/uk/gov/hmrc/play/http/HttpPostSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/http/HttpPostSpec.scala
@@ -35,6 +35,27 @@ class HttpPostSpec extends WordSpecLike with Matchers with CommonHttpBehaviour {
     def doPostAndRetrieveStream[I](url: String, body: I, headers: Seq[(String, String)])(implicit wts: Writes[I], hc: HeaderCarrier): Future[StreamingHttpResponse] = ???
   }
 
+  class StubbedStreamingHttpPost(doPostResult: Future[StreamingHttpResponse]) extends HttpPost with ConnectionTracingCapturing with MockAuditing {
+    def doPost[A](url: String, body: A, headers: Seq[(String,String)])(implicit rds: Writes[A], hc: HeaderCarrier) = ???
+    def doFormPost(url: String, body: Map[String, Seq[String]])(implicit hc: HeaderCarrier) = ???
+    def doPostString(url: String, body: String, headers: Seq[(String, String)])(implicit hc: HeaderCarrier) = ???
+    def doEmptyPost[A](url: String)(implicit hc: HeaderCarrier) = ???
+    def doPostAndRetrieveStream[I](url: String, body: I, headers: Seq[(String, String)])(implicit wts: Writes[I], hc: HeaderCarrier): Future[StreamingHttpResponse] = doPostResult
+  }
+
+  "HttpPost.POSTAndRetrieveStream" should {
+    val testObject = TestRequestClass("a", 1)
+    "be able to return streamed responses" in {
+      val response: DummyStreamingHttpResponse = new DummyStreamingHttpResponse(testBody, 200)
+      val testPOST: StubbedStreamingHttpPost = new StubbedStreamingHttpPost(Future.successful(response))
+      testPOST.POSTAndRetrieveStream(url, testObject).futureValue shouldBe response
+    }
+
+    behave like anErrorMappingStreamingHttpCall(POST, (url, responseF) => new StubbedStreamingHttpPost(responseF).POSTAndRetrieveStream(url, testObject))
+    behave like aTracingHttpCall(POST, "POST", new StubbedStreamingHttpPost(defaultStreamingHttpResponse)) { _.POSTAndRetrieveStream(url, testObject) }
+  }
+
+
   "HttpPost.POST" should {
     val testObject = TestRequestClass("a", 1)
     "be able to return plain responses" in {


### PR DESCRIPTION
Could you please review this change to allow streaming POST responses, this can be used when streaming PDFs or other binaries.