### PR TITLE
Auditing changes: client IP/port format + device ID

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,8 +3,8 @@ resolvers += Resolver.url("hmrc-sbt-plugin-releases",
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "0.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "0.8.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.4.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.8.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.8")

--- a/src/main/scala/uk/gov/hmrc/play/audit/http/HeaderCarrier.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/http/HeaderCarrier.scala
@@ -67,15 +67,15 @@ case class HeaderCarrier(authorization: Option[Authorization] = None,
 
   private lazy val auditTags = Map[String, String](
     names.xRequestId -> requestId.map(_.value).getOrElse("-"),
-    names.xSessionId -> sessionId.map(_.value).getOrElse("-")
+    names.xSessionId -> sessionId.map(_.value).getOrElse("-"),
+    "clientIP" -> trueClientIp.getOrElse("-"),
+    "clientPort" -> trueClientPort.getOrElse("-")
   )
 
   private lazy val auditDetails = Map[String, String](
     "ipAddress" -> forwarded.map(_.value).getOrElse("-"),
     names.authorisation -> authorization.map(_.value).getOrElse("-"),
-    names.token -> token.map(_.value).getOrElse("-"),
-    HeaderNames.trueClientIp -> trueClientIp.getOrElse(""),
-    HeaderNames.trueClientPort -> trueClientPort.getOrElse("")
+    names.token -> token.map(_.value).getOrElse("-")
   )
 
   def toAuditTags(transactionName: String, path: String) = {

--- a/src/main/scala/uk/gov/hmrc/play/audit/model/DeviceId.scala
+++ b/src/main/scala/uk/gov/hmrc/play/audit/model/DeviceId.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.audit.model
+
+import play.api.Logger._
+import play.api.mvc.RequestHeader
+
+
+case class DeviceId(id: String, hash: String)
+
+object DeviceId {
+
+  private val CookieName = "mdtpdi"
+
+  // device ID cookie value is made up of [device ID]_[hash of device ID]
+  private val DeviceIdPattern = """"?([^_^"]+)_([^_^"]+)"?""".r
+
+  def apply(request: RequestHeader): Option[DeviceId] = request.cookies.get(CookieName) match {
+    case Some(cookie) =>
+      cookie.value match {
+        case DeviceIdPattern(deviceId, hash) =>
+          debug(s"Device ID is '$deviceId'")
+          Some(DeviceId(deviceId, hash))
+        case _ =>
+          error(s"Failed to extract device ID from '${cookie.value}'")
+          None
+      }
+    case _ =>
+      error(s"Cannot get device ID for this request - cookie '$CookieName' not found")
+      None
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/play/audit/http/HttpAuditingSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/audit/http/HttpAuditingSpec.scala
@@ -112,8 +112,8 @@ class HttpAuditingSpec extends WordSpecLike with Matchers with Eventually with L
         dataEvent.auditSource shouldBe httpWithAudit.appName
         dataEvent.auditType shouldBe OutboundCall
 
-        dataEvent.request.tags shouldBe Map(xSessionId -> "-", xRequestId -> "-", TransactionName -> serviceUri, Path -> serviceUri)
-        dataEvent.request.detail shouldBe Map("ipAddress" -> "-", authorisation -> "-", token -> "-", Path -> serviceUri, Method -> getVerb, "surrogate" -> "true", "True-Client-IP" ->"", "True-Client-Port" ->"")
+        dataEvent.request.tags shouldBe Map(xSessionId -> "-", xRequestId -> "-", TransactionName -> serviceUri, Path -> serviceUri, "clientIP" -> "-", "clientPort" -> "-")
+        dataEvent.request.detail shouldBe Map("ipAddress" -> "-", authorisation -> "-", token -> "-", Path -> serviceUri, Method -> getVerb, "surrogate" -> "true")
         dataEvent.request.generatedAt shouldBe requestDateTime
 
         dataEvent.response.tags shouldBe empty
@@ -144,8 +144,8 @@ class HttpAuditingSpec extends WordSpecLike with Matchers with Eventually with L
         dataEvent.auditSource shouldBe httpWithAudit.appName
         dataEvent.auditType shouldBe OutboundCall
 
-        dataEvent.request.tags shouldBe Map(xSessionId -> "-", xRequestId -> "-", TransactionName -> serviceUri, Path -> serviceUri)
-        dataEvent.request.detail shouldBe Map("ipAddress" -> "-", authorisation -> "-", token -> "-", Path -> serviceUri, Method -> postVerb, RequestBody -> requestBody, "True-Client-IP" ->"", "True-Client-Port" ->"")
+        dataEvent.request.tags shouldBe Map(xSessionId -> "-", xRequestId -> "-", TransactionName -> serviceUri, Path -> serviceUri, "clientIP" -> "-", "clientPort" -> "-")
+          dataEvent.request.detail shouldBe Map("ipAddress" -> "-", authorisation -> "-", token -> "-", Path -> serviceUri, Method -> postVerb, RequestBody -> requestBody)
         dataEvent.request.generatedAt shouldBe requestDateTime
 
         dataEvent.response.tags shouldBe empty
@@ -198,8 +198,8 @@ class HttpAuditingSpec extends WordSpecLike with Matchers with Eventually with L
       dataEvent.auditSource shouldBe httpWithAudit.appName
       dataEvent.auditType shouldBe OutboundCall
 
-      dataEvent.request.tags shouldBe Map(xSessionId -> "-", xRequestId -> "-", TransactionName -> serviceUri, Path -> serviceUri)
-      dataEvent.request.detail shouldBe Map("ipAddress" -> "-", authorisation -> "-", token -> "-", Path -> serviceUri, Method -> getVerb, "surrogate" -> "true", "True-Client-IP" -> "192.168.1.2", "True-Client-Port" -> "12000")
+      dataEvent.request.tags shouldBe Map(xSessionId -> "-", xRequestId -> "-", TransactionName -> serviceUri, Path -> serviceUri, "clientIP" -> "192.168.1.2", "clientPort" -> "12000")
+      dataEvent.request.detail shouldBe Map("ipAddress" -> "-", authorisation -> "-", token -> "-", Path -> serviceUri, Method -> getVerb, "surrogate" -> "true")
       dataEvent.request.generatedAt shouldBe requestDateTime
 
       dataEvent.response.tags shouldBe empty
@@ -225,8 +225,8 @@ class HttpAuditingSpec extends WordSpecLike with Matchers with Eventually with L
       dataEvent.auditSource shouldBe httpWithAudit.appName
       dataEvent.auditType shouldBe OutboundCall
 
-      dataEvent.request.tags shouldBe Map(xSessionId -> "-", xRequestId -> "-", TransactionName -> serviceUri, Path -> serviceUri)
-      dataEvent.request.detail shouldBe Map("ipAddress" -> "-", authorisation -> "-", token -> "-", Path -> serviceUri, Method -> postVerb, RequestBody -> requestBody.get, "True-Client-IP" ->"", "True-Client-Port" ->"")
+      dataEvent.request.tags shouldBe Map(xSessionId -> "-", xRequestId -> "-", TransactionName -> serviceUri, Path -> serviceUri, "clientIP" -> "-", "clientPort" -> "-")
+      dataEvent.request.detail shouldBe Map("ipAddress" -> "-", authorisation -> "-", token -> "-", Path -> serviceUri, Method -> postVerb, RequestBody -> requestBody.get)
       dataEvent.request.generatedAt shouldBe requestDateTime
 
       dataEvent.response.tags shouldBe empty

--- a/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditTagsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/audit/http/connector/AuditTagsSpec.scala
@@ -40,12 +40,14 @@ class AuditTagsSpec extends WordSpecLike with Matchers {
 
       val tags = hc.toAuditTags("theTransactionName", "/the/request/path")
 
-      tags.size shouldBe 4
+      tags.size shouldBe 6
 
       tags(xSessionId) shouldBe sessionId.value
       tags(xRequestId) shouldBe requestId.value
       tags(TransactionName) shouldBe "theTransactionName"
       tags(Path) shouldBe "/the/request/path"
+      tags("clientIP") shouldBe "-"
+      tags("clientPort") shouldBe "-"
     }
 
     "be defaulted" in {
@@ -53,13 +55,25 @@ class AuditTagsSpec extends WordSpecLike with Matchers {
 
       val tags = hc.toAuditTags("defaultsWhenNothingSet", "/the/request/path")
 
-      tags.size shouldBe 4
+      tags.size shouldBe 6
 
       tags(xSessionId) shouldBe "-"
       tags(xRequestId) shouldBe "-"
       tags(TransactionName) shouldBe "defaultsWhenNothingSet"
       tags(Path) shouldBe "/the/request/path"
+      tags("clientIP") shouldBe "-"
+      tags("clientPort") shouldBe "-"
     }
+
+    "have more tags.clientIP and tags.clientPort" in {
+      val hc = HeaderCarrier(trueClientIp = Some("192.168.1.1"), trueClientPort =Some("9999"))
+
+      val tags = hc.toAuditTags("defaultsWhenNothingSet", "/the/request/path")
+
+      tags("clientIP") shouldBe "192.168.1.1"
+      tags("clientPort") shouldBe "9999"
+    }
+
   }
 
   "Audit DETAILS" should {
@@ -68,7 +82,7 @@ class AuditTagsSpec extends WordSpecLike with Matchers {
 
       val details = hc.toAuditDetails()
 
-      details.size shouldBe 5
+      details.size shouldBe 3
 
       details("ipAddress") shouldBe forwarded.value
       details(authorisation) shouldBe authorization.value
@@ -80,7 +94,7 @@ class AuditTagsSpec extends WordSpecLike with Matchers {
 
       val details = hc.toAuditDetails()
 
-      details.size shouldBe 5
+      details.size shouldBe 3
 
       details("ipAddress") shouldBe "-"
       details(authorisation) shouldBe "-"
@@ -92,14 +106,12 @@ class AuditTagsSpec extends WordSpecLike with Matchers {
 
       val details = hc.toAuditDetails("more-details" -> "the details", "lots-of-details" -> "interesting info")
 
-      details.size shouldBe 7
+      details.size shouldBe 5
 
       details("more-details") shouldBe "the details"
       details("lots-of-details") shouldBe "interesting info"
-      details(HeaderNames.trueClientIp) shouldBe "192.168.1.1"
-      details(HeaderNames.trueClientPort) shouldBe "9999"
-
     }
+
   }
 
 }

--- a/src/test/scala/uk/gov/hmrc/play/audit/model/DeviceIdSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/audit/model/DeviceIdSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.audit.model
+
+import org.scalatest.{Matchers, FlatSpec}
+import play.api.mvc.Cookie
+import play.api.test.{FakeRequest, FakeApplication, WithApplication}
+
+
+class DeviceIdSpec extends FlatSpec with Matchers {
+
+  val application = FakeApplication(
+    additionalConfiguration = Map("logger.application" -> "OFF")
+  )
+
+  "device id" should "be extracted from the mdtpdi cookie" in new WithApplication(application) {
+    val cookie = Cookie(name = "mdtpdi", value = "\"e09eebcc-9fd7-4b4d-abe7-88087a8e2741_7NiCRoHNO/3pJwKEWxRBQg==\"")
+    val request = FakeRequest().withCookies(cookie)
+    DeviceId(request) shouldBe Some(DeviceId("e09eebcc-9fd7-4b4d-abe7-88087a8e2741", "7NiCRoHNO/3pJwKEWxRBQg=="))
+  }
+
+  it should "be extracted from the mdtpdi cookie without extra double quotes" in new WithApplication(application) {
+    val cookie = Cookie(name = "mdtpdi", value = "e09eebcc-9fd7-4b4d-abe7-88087a8e2741_7NiCRoHNO/3pJwKEWxRBQg==")
+    val request = FakeRequest().withCookies(cookie)
+    DeviceId(request) shouldBe Some(DeviceId("e09eebcc-9fd7-4b4d-abe7-88087a8e2741", "7NiCRoHNO/3pJwKEWxRBQg=="))
+  }
+
+  it should "should not be extracted if the cookie is missing" in new WithApplication(application) {
+    DeviceId(FakeRequest()) shouldBe None
+  }
+
+  it should "should not be extracted if the cookie value is malformed" in new WithApplication(application) {
+    def shouldBeNone(value: String) = {
+      val cookie = Cookie(name = "mdtpdi", value = value)
+      val request = FakeRequest().withCookies(cookie)
+      DeviceId(request) shouldBe None
+    }
+    shouldBeNone("\"e09eebcc-9fd7-4b4d-abe7-88087a8e2741\"")
+    shouldBeNone("\"e09eebcc-9fd7-4b4d-abe7-88087a8e2741_\"")
+  }
+
+}


### PR DESCRIPTION
*Two changes to audit events:* 
- Adds support for extracting device ID from mdtpdi cookie 
- Rename to match auditing best practice guide: `detail.True-Client-IP` to `detail.clientIP` and `tags.True-Client-Port` to `tags.clientPort`

*Related stories*
- PE-1259
- TXM-420	