### PR TITLE
I've relaxed the protections ont he HttpErrorFunctions trait as well …

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/http/HttpErrorFunctions.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HttpErrorFunctions.scala
@@ -21,40 +21,40 @@ import java.util.concurrent.TimeoutException
 
 import scala.concurrent.{ExecutionContext, Future}
 
-protected[http] trait HttpErrorFunctions {
-  private def notFoundMessage(verbName: String, url: String, responseBody: String): String = {
+trait HttpErrorFunctions {
+  def notFoundMessage(verbName: String, url: String, responseBody: String): String = {
     s"$verbName of '$url' returned 404 (Not Found). Response body: '$responseBody'"
   }
 
-  private def preconditionFailedMessage(verbName: String, url: String, responseBody: String): String = {
+  def preconditionFailedMessage(verbName: String, url: String, responseBody: String): String = {
     s"$verbName of '$url' returned 412 (Precondition Failed). Response body: '$responseBody'"
   }
 
-  private def upstreamResponseMessage(verbName: String, url: String, status: Int, responseBody: String): String = {
+  def upstreamResponseMessage(verbName: String, url: String, status: Int, responseBody: String): String = {
     s"$verbName of '$url' returned $status. Response body: '$responseBody'"
   }
 
-  private def badRequestMessage(verbName: String, url: String, responseBody: String): String = {
+  def badRequestMessage(verbName: String, url: String, responseBody: String): String = {
     s"$verbName of '$url' returned 400 (Bad Request). Response body '$responseBody'"
   }
 
-  private def badGatewayMessage(verbName: String, url: String, status: Int, responseBody: String): String = {
+  def badGatewayMessage(verbName: String, url: String, status: Int, responseBody: String): String = {
     s"$verbName of '$url' returned status $status. Response body: '$responseBody'"
   }
 
-  private def badGatewayMessage(verbName: String, url: String, e: Exception): String = {
+  def badGatewayMessage(verbName: String, url: String, e: Exception): String = {
     s"$verbName of '$url' failed. Caused by: '${e.getMessage}'"
   }
 
-  private def gatewayTimeoutMessage(verbName: String, url: String, e: Exception): String = {
+  def gatewayTimeoutMessage(verbName: String, url: String, e: Exception): String = {
     s"$verbName of '$url' timed out with message '${e.getMessage}'"
   }
 
-  private def is2xx(status: Int) = status >= 200 && status < 300
+  def is2xx(status: Int) = status >= 200 && status < 300
 
-  private def is4xx(status: Int) = status >= 400 && status < 500
+  def is4xx(status: Int) = status >= 400 && status < 500
 
-  private def is5xx(status: Int) = status >= 500 && status < 600
+  def is5xx(status: Int) = status >= 500 && status < 600
 
   def handleResponse(httpMethod: String, url: String)(response: HttpResponse): HttpResponse =
     response.status match {


### PR DESCRIPTION
…as the various methods to check statuses and construct messages. This is to allow better re-use by other projects that want to piggyback on the implementation.

When I originally wrote that trait I was too conservative with the protections. I'm now in a situation with the VOA Rent Register project where I have created a new verb to let me do streaming Get requests and I have had to copy and paste HttpErrorFunctions in order to be able to re-use it. 

I know that various people are working on alternative approaches to streaming requests but none of them are currently in a state where they satisfy my needs, and relaxing these protections will let me get better re-use out of the existing library.