### PR TITLE
Refactor the connector to make it into a request builder.

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/connectors/Connector.scala
+++ b/src/main/scala/uk/gov/hmrc/play/connectors/Connector.scala
@@ -17,11 +17,21 @@
 package uk.gov.hmrc.play.connectors
 
 import play.api.Play.current
+import play.api.libs.ws.{WS, WSRequestHolder}
 import uk.gov.hmrc.play.http.HeaderCarrier
 
-trait Connector {
+trait RequestBuilder {
+  def buildRequest(url: String)(implicit hc: HeaderCarrier): WSRequestHolder
+}
 
-  import play.api.libs.ws.{WS, WSRequestHolder}
-
+trait PlayWSRequestBuilder extends RequestBuilder {
   def buildRequest(url: String)(implicit hc: HeaderCarrier): WSRequestHolder = WS.url(url).withHeaders(hc.headers: _*)
 }
+
+trait WSClientRequestBuilder extends RequestBuilder {
+  this: WSClientProvider =>
+  def buildRequest(url: String)(implicit hc: HeaderCarrier): WSRequestHolder = client.url(url).withHeaders(hc.headers: _*)
+}
+
+@deprecated("Please use PlayWSRequestBuilder instead", "3.1.0")
+trait Connector extends PlayWSRequestBuilder

--- a/src/main/scala/uk/gov/hmrc/play/connectors/WSClientProvider.scala
+++ b/src/main/scala/uk/gov/hmrc/play/connectors/WSClientProvider.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.connectors
+
+import play.api.libs.ws.{WSClient, DefaultWSClientConfig}
+import play.api.libs.ws.ning.NingAsyncHttpClientConfigBuilder
+
+trait WSClientProvider {
+  implicit val client: WSClient
+}
+
+trait DefaultWSClientProvider extends WSClientProvider {
+  val clientConfig = new DefaultWSClientConfig()
+  val secureDefaults:com.ning.http.client.AsyncHttpClientConfig = new NingAsyncHttpClientConfigBuilder(clientConfig).build()
+  val builder = new com.ning.http.client.AsyncHttpClientConfig.Builder(secureDefaults)
+  builder.setCompressionEnabled(true)
+  val secureDefaultsWithSpecificOptions:com.ning.http.client.AsyncHttpClientConfig = builder.build()
+
+  implicit val client = new play.api.libs.ws.ning.NingWSClient(secureDefaultsWithSpecificOptions)
+}

--- a/src/main/scala/uk/gov/hmrc/play/http/HttpVerb.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HttpVerb.scala
@@ -19,6 +19,6 @@ package uk.gov.hmrc.play.http
 import scala.concurrent.Future
 
 trait HttpVerb extends HttpErrorFunctions {
-  @deprecated("ProcessingFunction is obselete, use the relevant HttpReads[A] instead", "18/03/2015")
+  @deprecated("ProcessingFunction is obsolete, use the relevant HttpReads[A] instead", "18/03/2015")
   type ProcessingFunction = (Future[HttpResponse], String) => Future[HttpResponse]
 }


### PR DESCRIPTION
This change makes it possible to DI in an alternative implementation for the request builder.  It also introduces an interface for building request which makes it much easier to mix in.