### PR TITLE
Added a GET method to HttpGet that accepts query params as second arg

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/http/HttpGet.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HttpGet.scala
@@ -35,7 +35,7 @@ trait HttpGet extends HttpVerb with ConnectionTracing with HttpHooks {
     mapErrors(GET_VERB, url, httpResponse).map(response => rds.read(GET_VERB, url, response))
   }
 
-  def GET[A](url: String, queryParams: Seq[(String, String)])(implicit rds: HttpReads[A], hc: HeaderCarrier): Future[A] =withTracing(GET_VERB, url) {
+  def GET[A](url: String, queryParams: Seq[(String, String)])(implicit rds: HttpReads[A], hc: HeaderCarrier): Future[A] = {
     val queryString = makeQueryString(queryParams)
     if (url.contains("?")) {
       throw new UrlValidationException(url, s"${this.getClass}.GET(url, queryParams)", "Query parameters must be provided as a Seq of tuples to this method")

--- a/src/main/scala/uk/gov/hmrc/play/http/HttpGet.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HttpGet.scala
@@ -16,14 +16,14 @@
 
 package uk.gov.hmrc.play.http
 
-import uk.gov.hmrc.play.http.hooks.{HttpHook, HttpHooks}
-import uk.gov.hmrc.play.http.logging.{MdcLoggingExecutionContext, ConnectionTracing}
+import java.net.URLEncoder
+
+import play.api.http.HttpVerbs.{GET => GET_VERB}
+import uk.gov.hmrc.play.http.hooks.HttpHooks
+import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
+import uk.gov.hmrc.play.http.logging.{ConnectionTracing, MdcLoggingExecutionContext}
 
 import scala.concurrent.Future
-import play.api.libs.json
-import play.api.libs.json.{Json, JsValue}
-import MdcLoggingExecutionContext._
-import play.api.http.HttpVerbs.{GET => GET_VERB}
 
 trait HttpGet extends HttpVerb with ConnectionTracing with HttpHooks {
 
@@ -33,5 +33,20 @@ trait HttpGet extends HttpVerb with ConnectionTracing with HttpHooks {
     val httpResponse = doGet(url)
     executeHooks(url, GET_VERB, None, httpResponse)
     mapErrors(GET_VERB, url, httpResponse).map(response => rds.read(GET_VERB, url, response))
+  }
+
+  def GET[A](url: String, queryParams: Seq[(String, String)])(implicit rds: HttpReads[A], hc: HeaderCarrier): Future[A] =withTracing(GET_VERB, url) {
+    val queryString = makeQueryString(queryParams)
+    if (url.contains("?")) {
+      throw new UrlValidationException(url, s"${this.getClass}.GET(url, queryParams)", "Query parameters must be provided as a Seq of tuples to this method")
+    }
+    GET(url + queryString)
+  }
+
+  private def makeQueryString(queryParams: Seq[(String,String)]) = {
+    val paramPairs = queryParams.map(Function.tupled((k, v) => s"$k=${URLEncoder.encode(v, "utf-8")}"))
+    val params = paramPairs.mkString("&")
+
+    if (params.isEmpty) "" else s"?$params"
   }
 }

--- a/src/main/scala/uk/gov/hmrc/play/http/JsValidationException.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/JsValidationException.scala
@@ -27,3 +27,9 @@ class JsValidationException(val method: String,
     s"$method of '$url' returned invalid json. Attempting to convert to ${readingAs.getName} gave errors: $errors"
   }
 }
+
+class UrlValidationException(val url: String, val context: String, val message: String) extends Exception {
+  override def getMessage: String = {
+    s"'$url' is invalid for $context. $message"
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/play/http/HttpGetSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/http/HttpGetSpec.scala
@@ -52,13 +52,14 @@ class HttpGetSpec extends WordSpecLike with Matchers with ScalaFutures with Comm
     override def doGet(url: String)(implicit hc: HeaderCarrier): Future[HttpResponse] = doGetResult
   }
 
-  class UrlTestingHttpGet(expectedUrl: String) extends HttpGet {
+  class UrlTestingHttpGet() extends HttpGet {
     val testHook1 = mock[HttpHook]
     val testHook2 = mock[HttpHook]
     val hooks = Seq(testHook1, testHook2)
+    var lastUrl: Option[String] = None
 
     override def doGet(url: String)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
-      url shouldBe(expectedUrl)
+      lastUrl = Some(url)
       defaultHttpResponse
     }
   }
@@ -92,39 +93,44 @@ class HttpGetSpec extends WordSpecLike with Matchers with ScalaFutures with Comm
     }
   }
 
-  "HttpGet" should {
+  "HttpGet with params Seq" should {
     "return an empty string if the query parameters is empty" in {
-      val expected = "http://test.net"
-      val testGet = new UrlTestingHttpGet(expected)
+      val expected = Some("http://test.net")
+      val testGet = new UrlTestingHttpGet()
       testGet.GET("http://test.net", Seq())
+      testGet.lastUrl shouldBe expected
     }
 
     "return a url with a single param pair" in {
-      val expected = "http://test.net?one=1"
-      val testGet = new UrlTestingHttpGet(expected)
+      val expected = Some("http://test.net?one=1")
+      val testGet = new UrlTestingHttpGet()
       testGet.GET("http://test.net", Seq(("one", "1")))
+      testGet.lastUrl shouldBe expected
     }
 
     "return a url with a multiple param pairs" in {
-      val expected = "http://test.net?one=1&two=2&three=3"
-      val testGet = new UrlTestingHttpGet(expected)
+      val expected = Some("http://test.net?one=1&two=2&three=3")
+      val testGet = new UrlTestingHttpGet()
       testGet.GET("http://test.net", Seq(("one", "1"),("two", "2"), ("three", "3")))
+      testGet.lastUrl shouldBe expected
     }
 
     "return a url with encoded param pairs" in {
-      val expected = "http://test.net?email=test%2Balias%40email.com&data=%7B%22message%22%3A%22in+json+format%22%7D"
-      val testGet = new UrlTestingHttpGet(expected)
+      val expected = Some("http://test.net?email=test%2Balias%40email.com&data=%7B%22message%22%3A%22in+json+format%22%7D")
+      val testGet = new UrlTestingHttpGet()
       testGet.GET("http://test.net", Seq(("email", "test+alias@email.com"),("data", "{\"message\":\"in json format\"}")))
+      testGet.lastUrl shouldBe expected
     }
 
     "return a url with duplicate param pairs" in {
-      val expected = "http://test.net?one=1&two=2&one=11"
-      val testGet = new UrlTestingHttpGet(expected)
+      val expected = Some("http://test.net?one=1&two=2&one=11")
+      val testGet = new UrlTestingHttpGet()
       testGet.GET("http://test.net", Seq(("one", "1"),("two", "2"), ("one", "11")))
+      testGet.lastUrl shouldBe expected
     }
 
     "raise an exception if the URL provided already has a query string" in {
-      val testGet = new UrlTestingHttpGet("")
+      val testGet = new UrlTestingHttpGet()
 
       a [UrlValidationException] should be thrownBy testGet.GET("http://test.net?should=not=be+here", Seq(("one", "1")))
     }


### PR DESCRIPTION
This new method accepts a Seq of Pairs, one for each key value pair you want as query params. It URL encodes the values, joins with & and appends to the URL before delegating to the original GET method.