### PR TITLE
TXM-1154 ensure Akamai-Reputation header in HC by including all non-b…

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -68,7 +68,8 @@ private object AppDependencies {
         "org.scalacheck" %% "scalacheck" % "1.12.2" % scope,
         "org.pegdown" % "pegdown" % "1.5.0" % scope,
         "com.github.tomakehurst" % "wiremock" % "1.52" % scope,
-        "uk.gov.hmrc" %% "http-verbs-test" % "0.1.0" % scope
+        "uk.gov.hmrc" %% "http-verbs-test" % "0.1.0" % scope,
+        "org.scalatestplus" %% "play" % "1.2.0" % scope
       )
     }.test
   }

--- a/src/main/scala/uk/gov/hmrc/play/http/HeaderCarrier.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HeaderCarrier.scala
@@ -41,7 +41,7 @@ case class HeaderCarrier(authorization: Option[Authorization] = None,
                          gaUserId: Option[String] = None,
                          deviceID: Option[String] = None,
                          akamaiReputation: Option[AkamaiReputation] = None,
-                         remainingHeaders: Seq[(String, String)] = Seq()) extends  LoggingDetails with HeaderProvider {
+                         otherHeaders: Seq[(String, String)] = Seq()) extends  LoggingDetails with HeaderProvider {
 
   /**
    * @return the time, in nanoseconds, since this header carrier was created
@@ -63,7 +63,7 @@ case class HeaderCarrier(authorization: Option[Authorization] = None,
       gaUserId.map(HeaderNames.googleAnalyticUserId ->_),
       deviceID.map(HeaderNames.deviceID -> _),
       akamaiReputation.map(HeaderNames.akamaiReputation -> _.value)
-    ).flatten.toList ++ extraHeaders ++ remainingHeaders
+    ).flatten.toList ++ extraHeaders ++ otherHeaders
   }
 
   def withExtraHeaders(headers:(String, String)*) : HeaderCarrier = {
@@ -101,7 +101,7 @@ object HeaderCarrier {
       headers.get(HeaderNames.googleAnalyticUserId),
       headers.get(HeaderNames.deviceID),
       headers.get(HeaderNames.akamaiReputation).map(AkamaiReputation),
-      remainingHeaders(headers)
+      otherHeaders(headers)
     )
   }
 
@@ -122,7 +122,7 @@ object HeaderCarrier {
       headers.get(HeaderNames.googleAnalyticUserId),
       getDeviceId(cookies, headers),
       headers.get(HeaderNames.akamaiReputation).map(AkamaiReputation),
-      remainingHeaders(headers)
+      otherHeaders(headers)
     )
   }
 
@@ -132,7 +132,7 @@ object HeaderCarrier {
   }
 
 
-  private def remainingHeaders(headers: Headers): Seq[(String, String)] = {
+  private def otherHeaders(headers: Headers): Seq[(String, String)] = {
     val remaining = headers.keys.
       filterNot(HeaderNames.explicitlyIncludedHeaders.values.toSeq.contains(_)).
       filterNot(blacklistedHeaders.contains(_))

--- a/src/main/scala/uk/gov/hmrc/play/http/HeaderCarrier.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HeaderCarrier.scala
@@ -127,8 +127,7 @@ object HeaderCarrier {
   }
 
   val blacklistedHeaders: Seq[String] = {
-    // TODO sensible config key name and default values
-    Play.maybeApplication.flatMap(_.configuration.getStringSeq("blacklistedHttpHeaders")).getOrElse(Seq("User-Agent"))
+    Play.maybeApplication.flatMap(_.configuration.getStringSeq("httpHeadersBlacklist")).getOrElse(Seq("User-Agent"))
   }
 
   private def otherHeaders(headers: Headers): Seq[(String, String)] = {

--- a/src/main/scala/uk/gov/hmrc/play/http/HeaderCarrier.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HeaderCarrier.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.play.http
 
+import play.api.Play
 import play.api.mvc.{Cookies, Headers, Session}
 import uk.gov.hmrc.play.http.logging._
 
@@ -33,12 +34,14 @@ case class HeaderCarrier(authorization: Option[Authorization] = None,
                          requestId: Option[RequestId] = None,
                          requestChain: RequestChain = RequestChain.init,
                          nsStamp: Long = System.nanoTime(),
-                         extraHeaders: Seq[(String, String)] = Seq(), 
+                         extraHeaders: Seq[(String, String)] = Seq(),
                          trueClientIp: Option[String] = None,
                          trueClientPort: Option[String] = None,
                          gaToken: Option[String] = None,
                          gaUserId: Option[String] = None,
-                         deviceID: Option[String] = None) extends  LoggingDetails with HeaderProvider {
+                         deviceID: Option[String] = None,
+                         akamaiReputation: Option[AkamaiReputation] = None,
+                         remainingHeaders: Seq[(String, String)] = Seq()) extends  LoggingDetails with HeaderProvider {
 
   /**
    * @return the time, in nanoseconds, since this header carrier was created
@@ -53,13 +56,14 @@ case class HeaderCarrier(authorization: Option[Authorization] = None,
       forwarded.map(f => names.xForwardedFor -> f.value),
       token.map(t => names.token -> t.value),
       Some(names.xRequestChain -> requestChain.value),
-      authorization.map(auth => names.authorisation -> auth.value), 
+      authorization.map(auth => names.authorisation -> auth.value),
       trueClientIp.map(HeaderNames.trueClientIp ->_),
       trueClientPort.map(HeaderNames.trueClientPort ->_),
       gaToken.map(HeaderNames.googleAnalyticTokenId ->_),
       gaUserId.map(HeaderNames.googleAnalyticUserId ->_),
-      deviceID.map(HeaderNames.deviceID -> _)
-    ).flatten.toList ++ extraHeaders
+      deviceID.map(HeaderNames.deviceID -> _),
+      akamaiReputation.map(HeaderNames.akamaiReputation -> _.value)
+    ).flatten.toList ++ extraHeaders ++ remainingHeaders
   }
 
   def withExtraHeaders(headers:(String, String)*) : HeaderCarrier = {
@@ -95,7 +99,9 @@ object HeaderCarrier {
       headers.get(HeaderNames.trueClientPort),
       headers.get(HeaderNames.googleAnalyticTokenId),
       headers.get(HeaderNames.googleAnalyticUserId),
-      headers.get(HeaderNames.deviceID)
+      headers.get(HeaderNames.deviceID),
+      headers.get(HeaderNames.akamaiReputation).map(AkamaiReputation),
+      remainingHeaders(headers)
     )
   }
 
@@ -114,8 +120,23 @@ object HeaderCarrier {
       headers.get(HeaderNames.trueClientPort),
       headers.get(HeaderNames.googleAnalyticTokenId),
       headers.get(HeaderNames.googleAnalyticUserId),
-      getDeviceId(cookies, headers)
+      getDeviceId(cookies, headers),
+      headers.get(HeaderNames.akamaiReputation).map(AkamaiReputation),
+      remainingHeaders(headers)
     )
+  }
+
+  def blacklistedHeaders(): Seq[String] = {
+    // TODO sensible config key name and default values
+    Play.current.configuration.getStringSeq("blacklistedHttpHeaders").getOrElse(Seq("User-Agent"))
+  }
+
+
+  private def remainingHeaders(headers: Headers): Seq[(String, String)] = {
+    val remaining = headers.keys.
+      filterNot(HeaderNames.explicitlyIncludedHeaders.keySet.contains(_)).
+      filterNot(blacklistedHeaders().contains(_))
+    remaining.map(h => (h -> headers.get(h).getOrElse(""))).toSeq
   }
 
   private def forwardedFor(headers: Headers): Option[ForwardedFor] = {
@@ -126,7 +147,7 @@ object HeaderCarrier {
       case (Some(tcip), Some(xff)) => Some(s"$tcip, $xff")
     }).map(ForwardedFor)
   }
-  
+
   def buildRequestChain(currentChain: Option[String]): RequestChain = {
     currentChain match {
       case None => RequestChain.init
@@ -141,6 +162,6 @@ object HeaderCarrier {
       .getOrElse(System.nanoTime())
 
 
- 
+
 
 }

--- a/src/main/scala/uk/gov/hmrc/play/http/HeaderCarrier.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HeaderCarrier.scala
@@ -128,7 +128,7 @@ object HeaderCarrier {
 
   val blacklistedHeaders: Seq[String] = {
     // TODO sensible config key name and default values
-    Play.current.configuration.getStringSeq("blacklistedHttpHeaders").getOrElse(Seq("User-Agent"))
+    Play.maybeApplication.flatMap(_.configuration.getStringSeq("blacklistedHttpHeaders")).getOrElse(Seq("User-Agent"))
   }
 
 

--- a/src/main/scala/uk/gov/hmrc/play/http/HeaderCarrier.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HeaderCarrier.scala
@@ -131,12 +131,11 @@ object HeaderCarrier {
     Play.maybeApplication.flatMap(_.configuration.getStringSeq("blacklistedHttpHeaders")).getOrElse(Seq("User-Agent"))
   }
 
-
   private def otherHeaders(headers: Headers): Seq[(String, String)] = {
     val remaining = headers.keys.
-      filterNot(HeaderNames.explicitlyIncludedHeaders.values.toSeq.contains(_)).
+      filterNot(HeaderNames.explicitlyIncludedHeaders.contains(_)).
       filterNot(blacklistedHeaders.contains(_))
-    remaining.map(h => (h -> headers.get(h).getOrElse(""))).toSeq
+    remaining.map(h => h -> headers.get(h).getOrElse("")).toSeq
   }
 
   private def forwardedFor(headers: Headers): Option[ForwardedFor] = {

--- a/src/main/scala/uk/gov/hmrc/play/http/HeaderCarrier.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HeaderCarrier.scala
@@ -126,7 +126,7 @@ object HeaderCarrier {
     )
   }
 
-  def blacklistedHeaders(): Seq[String] = {
+  val blacklistedHeaders: Seq[String] = {
     // TODO sensible config key name and default values
     Play.current.configuration.getStringSeq("blacklistedHttpHeaders").getOrElse(Seq("User-Agent"))
   }
@@ -134,8 +134,8 @@ object HeaderCarrier {
 
   private def remainingHeaders(headers: Headers): Seq[(String, String)] = {
     val remaining = headers.keys.
-      filterNot(HeaderNames.explicitlyIncludedHeaders.keySet.contains(_)).
-      filterNot(blacklistedHeaders().contains(_))
+      filterNot(HeaderNames.explicitlyIncludedHeaders.values.toSeq.contains(_)).
+      filterNot(blacklistedHeaders.contains(_))
     remaining.map(h => (h -> headers.get(h).getOrElse(""))).toSeq
   }
 

--- a/src/main/scala/uk/gov/hmrc/play/http/HeaderNames.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HeaderNames.scala
@@ -20,20 +20,46 @@ object HeaderNames {
 
   import play.api.http.HeaderNames.AUTHORIZATION
 
-  val authorisation = AUTHORIZATION
-  val xForwardedFor = "x-forwarded-for"
-  val xRequestId = "X-Request-ID"
-  val xRequestTimestamp = "X-Request-Timestamp"
-  val xSessionId = "X-Session-ID"
-  val xRequestChain = "X-Request-Chain"
-  val trueClientIp = "True-Client-IP"
-  val trueClientPort = "True-Client-Port"
-  val token = "token"
-  val surrogate = "Surrogate"
-  val otacAuthorization = "Otac-Authorization"
-  val googleAnalyticTokenId = "ga-token"
-  val googleAnalyticUserId  = "ga-user-cookie-id"
-  val deviceID  = "deviceID" // not a typo, should be ID
+  /*
+   * this isn't ideal, but downstream apps still want to refer to typed header values
+   * and guarantee their explicit whitelisting whilst "remaining headers" should avoid
+   * duplicating these and creating unnecessary data on the wire.
+   * We could just model as a list but then accessing known header names would
+   * have to be done by magic number and would be susceptible to changes in ordering
+   */
+  val explicitlyIncludedHeaders = Map(
+    AUTHORIZATION -> AUTHORIZATION,
+    "x-forwarded-for" -> "x-forwarded-for",
+    "X-Request-ID" -> "X-Request-ID",
+    "X-Request-Timestamp" -> "X-Request-Timestamp",
+    "X-Session-ID" -> "X-Session-ID",
+    "X-Request-Chain" -> "X-Request-Chain",
+    "True-Client-IP" -> "True-Client-IP",
+    "True-Client-Port" -> "True-Client-Port",
+    "token" -> "token",
+    "Surrogate" -> "Surrogate",
+    "Otac-Authorization" -> "Otac-Authorization",
+    "ga-token" -> "ga-token",
+    "ga-user-cookie-id" -> "ga-user-cookie-id",
+    "deviceID" -> "deviceID", // not a typo, should be ID
+    "Akamai-Reputation" -> "Akamai-Reputation"
+  )
+
+  val authorisation = explicitlyIncludedHeaders.get(AUTHORIZATION).get
+  val xForwardedFor = explicitlyIncludedHeaders.get("x-forwarded-for").get
+  val xRequestId = explicitlyIncludedHeaders.get("X-Request-ID").get
+  val xRequestTimestamp = explicitlyIncludedHeaders.get("X-Request-Timestamp").get
+  val xSessionId = explicitlyIncludedHeaders.get("X-Session-ID").get
+  val xRequestChain = explicitlyIncludedHeaders.get("X-Request-Chain").get
+  val trueClientIp = explicitlyIncludedHeaders.get("True-Client-IP").get
+  val trueClientPort = explicitlyIncludedHeaders.get("True-Client-Port").get
+  val token = explicitlyIncludedHeaders.get("token").get
+  val surrogate = explicitlyIncludedHeaders.get("Surrogate").get
+  val otacAuthorization = explicitlyIncludedHeaders.get("Otac-Authorization").get
+  val googleAnalyticTokenId = explicitlyIncludedHeaders.get("ga-token").get
+  val googleAnalyticUserId  = explicitlyIncludedHeaders.get("ga-user-cookie-id").get
+  val deviceID  = explicitlyIncludedHeaders.get("deviceID").get
+  val akamaiReputation = explicitlyIncludedHeaders.get("Akamai-Reputation").get
 }
 
 object CookieNames {

--- a/src/main/scala/uk/gov/hmrc/play/http/HeaderNames.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/HeaderNames.scala
@@ -27,39 +27,40 @@ object HeaderNames {
    * We could just model as a list but then accessing known header names would
    * have to be done by magic number and would be susceptible to changes in ordering
    */
-  val explicitlyIncludedHeaders = Map(
-    AUTHORIZATION -> AUTHORIZATION,
-    "x-forwarded-for" -> "x-forwarded-for",
-    "X-Request-ID" -> "X-Request-ID",
-    "X-Request-Timestamp" -> "X-Request-Timestamp",
-    "X-Session-ID" -> "X-Session-ID",
-    "X-Request-Chain" -> "X-Request-Chain",
-    "True-Client-IP" -> "True-Client-IP",
-    "True-Client-Port" -> "True-Client-Port",
-    "token" -> "token",
-    "Surrogate" -> "Surrogate",
-    "Otac-Authorization" -> "Otac-Authorization",
-    "ga-token" -> "ga-token",
-    "ga-user-cookie-id" -> "ga-user-cookie-id",
-    "deviceID" -> "deviceID", // not a typo, should be ID
-    "Akamai-Reputation" -> "Akamai-Reputation"
-  )
 
-  val authorisation = explicitlyIncludedHeaders.get(AUTHORIZATION).get
-  val xForwardedFor = explicitlyIncludedHeaders.get("x-forwarded-for").get
-  val xRequestId = explicitlyIncludedHeaders.get("X-Request-ID").get
-  val xRequestTimestamp = explicitlyIncludedHeaders.get("X-Request-Timestamp").get
-  val xSessionId = explicitlyIncludedHeaders.get("X-Session-ID").get
-  val xRequestChain = explicitlyIncludedHeaders.get("X-Request-Chain").get
-  val trueClientIp = explicitlyIncludedHeaders.get("True-Client-IP").get
-  val trueClientPort = explicitlyIncludedHeaders.get("True-Client-Port").get
-  val token = explicitlyIncludedHeaders.get("token").get
-  val surrogate = explicitlyIncludedHeaders.get("Surrogate").get
-  val otacAuthorization = explicitlyIncludedHeaders.get("Otac-Authorization").get
-  val googleAnalyticTokenId = explicitlyIncludedHeaders.get("ga-token").get
-  val googleAnalyticUserId  = explicitlyIncludedHeaders.get("ga-user-cookie-id").get
-  val deviceID  = explicitlyIncludedHeaders.get("deviceID").get
-  val akamaiReputation = explicitlyIncludedHeaders.get("Akamai-Reputation").get
+  val authorisation = AUTHORIZATION
+  val xForwardedFor = "x-forwarded-for"
+  val xRequestId =  "X-Request-ID"
+  val xRequestTimestamp = "X-Request-Timestamp"
+  val xSessionId = "X-Session-ID"
+  val xRequestChain = "X-Request-Chain"
+  val trueClientIp = "True-Client-IP"
+  val trueClientPort = "True-Client-Port"
+  val token = "token"
+  val surrogate = "Surrogate"
+  val otacAuthorization = "Otac-Authorization"
+  val googleAnalyticTokenId = "ga-token"
+  val googleAnalyticUserId  = "ga-user-cookie-id"
+  val deviceID  = "deviceID" // not a typo, should be ID
+  val akamaiReputation = "Akamai-Reputation"
+
+  val explicitlyIncludedHeaders = Seq(
+    authorisation,
+    xForwardedFor,
+    xRequestId,
+    xRequestTimestamp,
+    xSessionId,
+    xRequestChain,
+    trueClientIp,
+    trueClientPort,
+    token,
+    surrogate,
+    otacAuthorization,
+    googleAnalyticTokenId,
+    googleAnalyticUserId,
+    deviceID, // not a typo, should be ID
+    akamaiReputation
+  )
 }
 
 object CookieNames {

--- a/src/main/scala/uk/gov/hmrc/play/http/logging/LoggingDetails.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/logging/LoggingDetails.scala
@@ -26,6 +26,8 @@ case class SessionId(value: String) extends AnyVal
 
 case class RequestId(value: String) extends AnyVal
 
+case class AkamaiReputation(value: String) extends AnyVal
+
 case class RequestChain(value: String) extends AnyVal {
   def extend = RequestChain(s"$value-${RequestChain.newComponent}")
 }

--- a/src/main/scala/uk/gov/hmrc/play/http/ws/WSRequest.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/ws/WSRequest.scala
@@ -49,7 +49,7 @@ trait WSRequest {
     if (internalHostPatterns.exists(_.pattern.matcher(u.getHost).matches())) {
       hc.headers
     } else {
-      hc.headers.filterNot(hc.remainingHeaders.contains(_))
+      hc.headers.filterNot(hc.otherHeaders.contains(_))
     }
   }
 }

--- a/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierSpec.scala
@@ -17,16 +17,18 @@
 package uk.gov.hmrc.play.http
 
 import org.scalatest.{Matchers, WordSpecLike}
-import play.api.mvc.{Cookie, Action, Controller, Session}
-import play.api.test.{FakeRequest, FakeApplication, FakeHeaders}
+import org.scalatestplus.play.OneAppPerSuite
+import play.api.mvc.{Action, Controller, Cookie, Session}
+import play.api.test.{FakeApplication, FakeHeaders, FakeRequest}
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.http.HeaderCarrier.fromHeadersAndSession
-import uk.gov.hmrc.play.http.logging.{Authorization, ForwardedFor, RequestId, SessionId}
+import uk.gov.hmrc.play.http.logging._
 
 import scala.concurrent.duration._
 
-class HeaderCarrierSpec extends WordSpecLike with Matchers {
+class HeaderCarrierSpec extends WordSpecLike with Matchers with OneAppPerSuite {
 
+  override implicit lazy val app: FakeApplication = FakeApplication(additionalConfiguration = Map("blacklistedHttpHeaders" -> Seq("foo", "baz")))
 
   "Extracting the request timestamp from the session and headers" should {
     "find it in the header if present and a valid Long" in {
@@ -103,6 +105,14 @@ class HeaderCarrierSpec extends WordSpecLike with Matchers {
 
     "ignore the sessionId when it is not present in the headers nor session" in {
       fromHeadersAndSession(headers(), Some(Session(Map.empty))).sessionId shouldBe None
+    }
+
+    "find the akamai reputation from the headers" in {
+      fromHeadersAndSession(headers(HeaderNames.akamaiReputation -> "ID=127.0.0.1;WEBATCK=7"), Some(Session())).akamaiReputation shouldBe Some(AkamaiReputation("ID=127.0.0.1;WEBATCK=7"))
+    }
+
+    "add all non-blacklisted remaining headers" in {
+      fromHeadersAndSession(headers("foo" -> "bar", "bar" -> "baz", "baz" -> "quix", "quix" -> "foo"), Some(Session())).remainingHeaders shouldBe Seq("bar" -> "baz", "quix" -> "foo")
     }
 
   }

--- a/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierSpec.scala
@@ -26,9 +26,7 @@ import uk.gov.hmrc.play.http.logging._
 
 import scala.concurrent.duration._
 
-class HeaderCarrierSpec extends WordSpecLike with Matchers with OneAppPerSuite {
-
-  override implicit lazy val app: FakeApplication = FakeApplication(additionalConfiguration = Map("blacklistedHttpHeaders" -> Seq("foo", "baz")))
+class HeaderCarrierSpec extends WordSpecLike with Matchers {
 
   "Extracting the request timestamp from the session and headers" should {
     "find it in the header if present and a valid Long" in {
@@ -111,8 +109,8 @@ class HeaderCarrierSpec extends WordSpecLike with Matchers with OneAppPerSuite {
       fromHeadersAndSession(headers(HeaderNames.akamaiReputation -> "ID=127.0.0.1;WEBATCK=7"), Some(Session())).akamaiReputation shouldBe Some(AkamaiReputation("ID=127.0.0.1;WEBATCK=7"))
     }
 
-    "add all non-blacklisted remaining headers" in {
-      fromHeadersAndSession(headers("foo" -> "bar", "bar" -> "baz", "baz" -> "quix", "quix" -> "foo"), Some(Session())).remainingHeaders shouldBe Seq("bar" -> "baz", "quix" -> "foo")
+    "add all non-blacklisted remaining headers" in  {
+      fromHeadersAndSession(headers("User-Agent" -> "quix", "quix" -> "foo"), Some(Session())).remainingHeaders shouldBe Seq("quix" -> "foo")
     }
 
   }

--- a/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierSpec.scala
@@ -110,7 +110,7 @@ class HeaderCarrierSpec extends WordSpecLike with Matchers {
     }
 
     "add all non-blacklisted remaining headers" in  {
-      fromHeadersAndSession(headers("User-Agent" -> "quix", "quix" -> "foo"), Some(Session())).remainingHeaders shouldBe Seq("quix" -> "foo")
+      fromHeadersAndSession(headers("User-Agent" -> "quix", "quix" -> "foo"), Some(Session())).otherHeaders shouldBe Seq("quix" -> "foo")
     }
 
   }

--- a/src/test/scala/uk/gov/hmrc/play/http/ws/WSRequestSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/http/ws/WSRequestSpec.scala
@@ -56,6 +56,38 @@ class WSRequestSpec extends WordSpecLike with Matchers {
       wsRequest.headers("User-Agent").head shouldBe "test-client"
     }
 
+    "filter 'remaining headers' from request for external service calls" in
+      running(FakeApplication(additionalConfiguration = Map("internalServiceHostPatterns" -> List("^.*\\.service$", "^localhost$")))) {
+        val url = "http://test.me/baz" // an external service call, according to config
+        implicit val hc = HeaderCarrier(
+            remainingHeaders = Seq("foo" -> "secret!")
+          )
+        val req = new WSRequest() {}
+        val res = req.buildRequest(url)
+        res.headers.get("foo") shouldBe None
+    }
+
+    "include 'remaining headers' in request for internal service call to .service URL" in
+      running(FakeApplication(additionalConfiguration = Map("internalServiceHostPatterns" -> List("^.*\\.service$", "^localhost$")))) {
+        val url = "http://test.service/bar" // an internal service call, according to config
+        implicit val hc = HeaderCarrier(
+            remainingHeaders = Seq("foo" -> "secret!")
+          )
+        val req = new WSRequest() {}
+        val res = req.buildRequest(url)
+        res.headers.get("foo") shouldBe Some(List("secret!"))
+      }
+
+    "include 'remaining headers' in request for internal service call to other configured internal URL pattern" in
+      running(FakeApplication(additionalConfiguration = Map("internalServiceHostPatterns" -> List("^.*\\.service$", "^localhost$")))) {
+        val url = "http://localhost/foo" // an internal service call, according to config
+        implicit val hc = HeaderCarrier(
+            remainingHeaders = Seq("foo" -> "secret!")
+          )
+        val req = new WSRequest() {}
+        val res = req.buildRequest(url)
+        res.headers.get("foo") shouldBe Some(List("secret!"))
+      }
 
   }
 

--- a/src/test/scala/uk/gov/hmrc/play/http/ws/WSRequestSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/http/ws/WSRequestSpec.scala
@@ -60,7 +60,7 @@ class WSRequestSpec extends WordSpecLike with Matchers {
       running(FakeApplication(additionalConfiguration = Map("internalServiceHostPatterns" -> List("^.*\\.service$", "^localhost$")))) {
         val url = "http://test.me/baz" // an external service call, according to config
         implicit val hc = HeaderCarrier(
-            remainingHeaders = Seq("foo" -> "secret!")
+            otherHeaders = Seq("foo" -> "secret!")
           )
         val req = new WSRequest() {}
         val res = req.buildRequest(url)
@@ -71,7 +71,7 @@ class WSRequestSpec extends WordSpecLike with Matchers {
       running(FakeApplication(additionalConfiguration = Map("internalServiceHostPatterns" -> List("^.*\\.service$", "^localhost$")))) {
         val url = "http://test.service/bar" // an internal service call, according to config
         implicit val hc = HeaderCarrier(
-            remainingHeaders = Seq("foo" -> "secret!")
+            otherHeaders = Seq("foo" -> "secret!")
           )
         val req = new WSRequest() {}
         val res = req.buildRequest(url)
@@ -82,7 +82,7 @@ class WSRequestSpec extends WordSpecLike with Matchers {
       running(FakeApplication(additionalConfiguration = Map("internalServiceHostPatterns" -> List("^.*\\.service$", "^localhost$")))) {
         val url = "http://localhost/foo" // an internal service call, according to config
         implicit val hc = HeaderCarrier(
-            remainingHeaders = Seq("foo" -> "secret!")
+            otherHeaders = Seq("foo" -> "secret!")
           )
         val req = new WSRequest() {}
         val res = req.buildRequest(url)


### PR DESCRIPTION
…lacklisted headers

Further to recent discussion on #team-platops around extracting addition of headers to header carrier from code, this change set introduces forwarding of all headers with a configurable blacklist via Play config.