### PR TITLE
RestFormats: Accept DateTimes without milliseconds

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/controllers/RestFormats.scala
+++ b/src/main/scala/uk/gov/hmrc/play/controllers/RestFormats.scala
@@ -26,16 +26,17 @@ object RestFormats extends RestFormats
 
 trait RestFormats {
 
-  private val dateTimeFormat = ISODateTimeFormat.dateTime.withZoneUTC
+  private val dateTimeReadParser = ISODateTimeFormat.dateTimeParser.withZoneUTC
+  private val dateTimeWriteFormat = ISODateTimeFormat.dateTime.withZoneUTC
   private val localDateRegex = """^(\d\d\d\d)-(\d\d)-(\d\d)$""".r
 
   implicit val localDateTimeRead: Reads[LocalDateTime] = new Reads[LocalDateTime] {
     override def reads(json: JsValue): JsResult[LocalDateTime] = {
       json match {
         case JsString(s) => Try {
-          JsSuccess(new LocalDateTime(dateTimeFormat.parseDateTime(s), DateTimeZone.UTC))
+          JsSuccess(new LocalDateTime(dateTimeReadParser.parseDateTime(s), DateTimeZone.UTC))
         }.getOrElse {
-          JsError(s"Could not parse $s as a DateTime with format ${dateTimeFormat.toString}")
+          JsError(s"Could not parse $s as a DateTime with format ${dateTimeReadParser.toString}")
         }
         case _ => JsError(s"Expected value to be a string, was actually $json")
       }
@@ -43,16 +44,16 @@ trait RestFormats {
   }
 
   implicit val localDateTimeWrite: Writes[LocalDateTime] = new Writes[LocalDateTime] {
-    def writes(dateTime: LocalDateTime): JsValue = JsString(dateTimeFormat.print(dateTime.toDateTime(DateTimeZone.UTC)))
+    def writes(dateTime: LocalDateTime): JsValue = JsString(dateTimeWriteFormat.print(dateTime.toDateTime(DateTimeZone.UTC)))
   }
 
   implicit val dateTimeRead: Reads[DateTime] = new Reads[DateTime] {
     override def reads(json: JsValue): JsResult[DateTime] = {
       json match {
         case JsString(s) => Try {
-          JsSuccess(dateTimeFormat.parseDateTime(s))
+          JsSuccess(dateTimeReadParser.parseDateTime(s))
         }.getOrElse {
-          JsError(s"Could not parse $s as a DateTime with format ${dateTimeFormat.toString}")
+          JsError(s"Could not parse $s as a DateTime with format ${dateTimeReadParser.toString}")
         }
         case _ => JsError(s"Expected value to be a string, was actually $json")
       }
@@ -60,7 +61,7 @@ trait RestFormats {
   }
 
   implicit val dateTimeWrite: Writes[DateTime] = new Writes[DateTime] {
-    def writes(dateTime: DateTime): JsValue = JsString(dateTimeFormat.print(dateTime))
+    def writes(dateTime: DateTime): JsValue = JsString(dateTimeWriteFormat.print(dateTime))
   }
 
   implicit val localDateRead: Reads[LocalDate] = new Reads[LocalDate] {

--- a/src/test/scala/uk/gov/hmrc/play/controllers/RestFormatsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/controllers/RestFormatsSpec.scala
@@ -30,6 +30,14 @@ class RestFormatsSpec extends WordSpecLike with Matchers {
       result shouldBe testDate
     }
 
+    "accept strings formatted without a millisecond component" in {
+      val testDate = new LocalDateTime(0, DateTimeZone.UTC)
+      val jsValue: JsValue = JsString("1970-01-01T00:00:00")
+
+      val JsSuccess(result, _) = RestFormats.localDateTimeRead.reads(jsValue)
+      result shouldBe testDate
+    }
+
     "return a JsError for a json value that is not a JsString" in {
       RestFormats.localDateTimeRead.reads(Json.obj()) shouldBe a[JsError]
     }
@@ -43,6 +51,14 @@ class RestFormatsSpec extends WordSpecLike with Matchers {
     "return a DateTime in zone UTC for correctly formatted JsString" in {
       val testDate = new DateTime(0)
       val jsValue = RestFormats.dateTimeWrite.writes(testDate)
+
+      val JsSuccess(result, _) = RestFormats.dateTimeRead.reads(jsValue)
+      result shouldBe testDate.withZone(DateTimeZone.UTC)
+    }
+
+    "accept strings formatted without a millisecond component" in {
+      val testDate = new DateTime(0)
+      val jsValue: JsValue = JsString("1970-01-01T00:00:00+00:00")
 
       val JsSuccess(result, _) = RestFormats.dateTimeRead.reads(jsValue)
       result shouldBe testDate.withZone(DateTimeZone.UTC)


### PR DESCRIPTION
Our developer hub says that our external APIs support timestamps formatted without milliseconds: https://developer.service.hmrc.gov.uk/api-documentation/docs/reference-guide#common-data-types

This change allows services implementing 3rd party APIs to use RestFormats.dateTimeRead and be compatible with the above documentation.