### PR TITLE
Update deprecated ws configuration parameters

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ws.timeout.request=20000    #20 secs
-ws.timeout.connection=6000  #6 secs
+play.ws.timeout.request=20000    #20 secs
+play.ws.timeout.connection=6000  #6 secs


### PR DESCRIPTION
ws.* config settings have changed to play.ws.*
see https://www.playframework.com/documentation/2.5.x/ScalaWS#Configuring-Timeouts

This change does not require a new release as it is simply cleaning up deprecation warnings, it can just be included in the next one whenever that is.