### PR TITLE
Refactor to use standard sbt build structure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: scala
 scala:
-- 2.11.7
+- 2.11.8
 jdk:
 - oraclejdk8
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,16 @@
+import uk.gov.hmrc.DefaultBuildSettings.targetJvm
+
+enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning)
+
+name := "http-verbs"
+
+scalaVersion := "2.11.8"
+crossScalaVersions := Seq("2.11.8")
+targetJvm := "jvm-1.8"
+
+libraryDependencies ++= AppDependencies()
+
+resolvers := Seq(
+  Resolver.bintrayRepo("hmrc", "releases"),
+  Resolver.typesafeRepo("releases")
+)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -13,31 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import sbt.Keys._
 import sbt._
-import uk.gov.hmrc.versioning.SbtGitVersioning
 
-object HmrcBuild extends Build {
-
-  import uk.gov.hmrc._
-
-  val appName = "http-verbs"
-
-  lazy val microservice = Project(appName, file("."))
-    .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning)
-    .settings(
-      scalaVersion := "2.11.8",
-      libraryDependencies ++= AppDependencies(),
-      crossScalaVersions := Seq("2.11.8"),
-      resolvers := Seq(
-        Resolver.bintrayRepo("hmrc", "releases"),
-        Resolver.typesafeRepo("releases")
-      )
-    )
-}
-
-private object AppDependencies {
+object AppDependencies {
 
   val compile = Seq(
     "com.typesafe.play" %% "play-json" % "2.5.16",

--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -27,12 +27,12 @@ object HmrcBuild extends Build {
   lazy val microservice = Project(appName, file("."))
     .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning)
     .settings(
-      scalaVersion := "2.11.7",
+      scalaVersion := "2.11.8",
       libraryDependencies ++= AppDependencies(),
-      crossScalaVersions := Seq("2.11.7"),
+      crossScalaVersions := Seq("2.11.8"),
       resolvers := Seq(
         Resolver.bintrayRepo("hmrc", "releases"),
-        "typesafe-releases" at "http://repo.typesafe.com/typesafe/releases/"
+        Resolver.typesafeRepo("releases")
       )
     )
 }
@@ -40,7 +40,7 @@ object HmrcBuild extends Build {
 private object AppDependencies {
 
   val compile = Seq(
-    "com.typesafe.play" %% "play-json" % "2.5.15",
+    "com.typesafe.play" %% "play-json" % "2.5.16",
     "uk.gov.hmrc" %% "time" % "2.0.0",
     "uk.gov.hmrc" %% "http-core" % "0.5.0"
   )
@@ -51,19 +51,17 @@ private object AppDependencies {
     lazy val test: Seq[ModuleID] = ???
   }
 
-
-
   object Test {
     def apply() = new TestDependencies {
       override lazy val test = Seq(
         "commons-codec" % "commons-codec" % "1.7" % scope,
-        "org.scalatest" %% "scalatest" % "2.2.4" % scope,
-        "org.scalacheck" %% "scalacheck" % "1.12.2" % scope,
-        "org.pegdown" % "pegdown" % "1.5.0" % scope,
+        "org.scalatest" %% "scalatest" % "3.0.3" % scope,
+        "org.scalacheck" %% "scalacheck" % "1.13.4" % scope,
+        "org.pegdown" % "pegdown" % "1.6.0" % scope,
         "com.github.tomakehurst" % "wiremock" % "1.52" % scope,
-        "ch.qos.logback" % "logback-core" % "1.1.7",
-        "ch.qos.logback" % "logback-classic" % "1.1.7",
-        "org.mockito" % "mockito-all" % "1.10.19" % "test"
+        "ch.qos.logback" % "logback-core" % "1.1.7" % scope,
+        "ch.qos.logback" % "logback-classic" % "1.1.7" % scope,
+        "org.mockito" % "mockito-all" % "1.10.19"  % scope
       )
     }.test
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-sbt.version=0.13.11
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += Resolver.url("hmrc-sbt-plugin-releases",
   url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.4.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.9.0")

--- a/src/test/scala/uk/gov/hmrc/http/HttpDeleteSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/http/HttpDeleteSpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.http
 
 import com.typesafe.config.Config
 import org.mockito.Mockito._
+import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{Matchers, WordSpecLike}
@@ -46,7 +47,7 @@ class HttpDeleteSpec extends WordSpecLike with Matchers with MockitoSugar with C
     }
     "be able to return objects deserialised from JSON" in {
       val testDelete = new StubbedHttpDelete(Future.successful(new DummyHttpResponse("""{"foo":"t","bar":10}""", 200)))
-      testDelete.DELETE[TestClass](url).futureValue(PatienceConfig(Span(2, Seconds), Span(15, Millis))) should be (TestClass("t", 10))
+      testDelete.DELETE[TestClass](url).futureValue(Timeout(Span(2, Seconds)), Interval(Span(15, Millis))) shouldBe TestClass("t", 10)
     }
     behave like anErrorMappingHttpCall("DELETE", (url, responseF) => new StubbedHttpDelete(responseF).DELETE(url))
     behave like aTracingHttpCall("DELETE", "DELETE", new StubbedHttpDelete(defaultHttpResponse)) { _.DELETE(url) }


### PR DESCRIPTION
This removes the use of deprecated Build object