### PR TITLE
Added HttpPut.PUTString. Equivalent to HttpPost.POSTString.

### DIFF
--- a/src/main/scala/uk/gov/hmrc/http/HttpPut.scala
+++ b/src/main/scala/uk/gov/hmrc/http/HttpPut.scala
@@ -34,4 +34,15 @@ trait HttpPut extends CorePut with PutHttpTransport with HttpVerb with Connectio
       mapErrors(PUT_VERB, url, httpResponse).map(response => rds.read(PUT_VERB, url, response))
     }
 
+  override def PUTString[O](url: String, body: String, headers: Seq[(String, String)])(
+    implicit rds: HttpReads[O],
+    hc: HeaderCarrier,
+    ec: ExecutionContext): Future[O] =
+    withTracing(PUT_VERB, url) {
+      val httpResponse = retry(PUT_VERB, url)(doPutString(url, body, headers))
+      executeHooks(url, PUT_VERB, Option(body), httpResponse)
+      mapErrors(PUT_VERB, url, httpResponse).map(rds.read(PUT_VERB, url, _))
+    }
+
+
 }

--- a/src/main/scala/uk/gov/hmrc/http/HttpTransport.scala
+++ b/src/main/scala/uk/gov/hmrc/http/HttpTransport.scala
@@ -34,6 +34,8 @@ trait PatchHttpTransport {
 
 trait PutHttpTransport {
   def doPut[A](url: String, body: A)(implicit rds: Writes[A], hc: HeaderCarrier): Future[HttpResponse]
+  def doPutString(url: String, body: String, headers: Seq[(String, String)])(
+    implicit hc: HeaderCarrier): Future[HttpResponse]
 }
 
 trait PostHttpTransport {
@@ -77,6 +79,10 @@ trait CorePut {
   def PUT[I, O](
     url: String,
     body: I)(implicit wts: Writes[I], rds: HttpReads[O], hc: HeaderCarrier, ec: ExecutionContext): Future[O]
+  def PUTString[O](url: String, body: String, headers: Seq[(String, String)] = Seq.empty)(
+    implicit rds: HttpReads[O],
+    hc: HeaderCarrier,
+    ec: ExecutionContext): Future[O]
 }
 
 trait CorePost {

--- a/src/main/scala/uk/gov/hmrc/play/http/ws/WSPut.scala
+++ b/src/main/scala/uk/gov/hmrc/play/http/ws/WSPut.scala
@@ -28,4 +28,11 @@ trait WSPut extends CorePut with PutHttpTransport with WSRequest {
 
     buildRequest(url).put(Json.toJson(body)).map(new WSHttpResponse(_))
   }
+
+  override def doPutString(url: String, body: String, headers: Seq[(String, String)])(
+    implicit hc: HeaderCarrier): Future[HttpResponse] = {
+    import play.api.libs.concurrent.Execution.Implicits.defaultContext
+
+    buildRequest(url).withHeaders(headers: _*).put(body).map(new WSHttpResponse(_))
+  }
 }

--- a/src/test/scala/uk/gov/hmrc/http/RetriesSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/http/RetriesSpec.scala
@@ -225,7 +225,7 @@ class RetriesSpec extends WordSpec with Matchers with MockitoSugar with ScalaFut
 
   "PUT" should {
     "retry on SSLException with message 'SSLEngine closed already'" in {
-      val http = new HttpPut with TestHttpVerb {
+      val http = new TestHttpPut with TestHttpVerb {
         override def doPut[A](url: String, body: A)(implicit rds: Writes[A], hc: HeaderCarrier): Future[HttpResponse] =
           failFewTimesAndThenSucceed(
             success   = Future.successful(HttpResponse(404)),
@@ -346,4 +346,9 @@ class RetriesSpec extends WordSpec with Matchers with MockitoSugar with ScalaFut
       implicit hc: HeaderCarrier): Future[HttpResponse] = ???
   }
 
+  trait TestHttpPut extends HttpPut {
+    def doPut[A](url: String, body: A)(implicit rds: Writes[A], hc: HeaderCarrier): Future[HttpResponse] = ???
+    def doPutString(url: String, body: String, headers: Seq[(String, String)])(
+      implicit hc: HeaderCarrier): Future[HttpResponse] = ???
+  }
 }

--- a/src/test/scala/uk/gov/hmrc/play/test/helpers.scala
+++ b/src/test/scala/uk/gov/hmrc/play/test/helpers.scala
@@ -67,6 +67,11 @@ trait TestHttpCore extends CorePost with CoreGet with CorePut with CorePatch wit
     url: String,
     body: I)(implicit wts: Writes[I], rds: HttpReads[O], hc: HeaderCarrier, ec: ExecutionContext): Future[O] = ???
 
+  override def PUTString[O](url: String, body: String, headers: Seq[(String, String)])(
+    implicit rds: HttpReads[O],
+    hc: HeaderCarrier,
+    ec: ExecutionContext): Future[O] = ???
+
   override def PATCH[I, O](
     url: String,
     body: I)(implicit wts: Writes[I], rds: HttpReads[O], hc: HeaderCarrier, ec: ExecutionContext): Future[O] = ???


### PR DESCRIPTION
I need an HttpPut.PUTString equivalent to the HttpPost.POSTString. Mostly copying what is there for HttpPost.POSTString & related methods.