### PR TITLE
Scala cross build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 sudo: false
 language: scala
-scala:
-- 2.11.8
 jdk:
 - oraclejdk8
+
+matrix:
+  include:
+    - scala: 2.11.12
+      env: PLAY_VERSION=2.5
+    - scala: 2.11.12
+      env: PLAY_VERSION=2.6
+    - scala: 2.12.8
+      env: PLAY_VERSION=2.6
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val library = Project(name, file("."))
     makePublicallyAvailableOnBintray := true
   ).settings(
     scalaVersion        := "2.11.12",
-    crossScalaVersions  := Seq("2.11.12"),
+    crossScalaVersions  := Seq("2.11.12", "2.12.8"),
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
     PlayCrossCompilation.playCrossCompilationSettings,
     scalacOptions       ++= Seq("-deprecation"),

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -26,10 +26,9 @@ object AppDependencies {
       shared = Seq(
         "com.typesafe" % "config"    % "1.3.3",
         "org.slf4j"    % "slf4j-api" % "1.7.25",
-        // empty http-core and http-verbs-play-25 added to force eviction
-        // as classes from these two libs have been inlined in http-verbs
-        "uk.gov.hmrc" %% "http-core"          % "2.1.0",
-        "uk.gov.hmrc" %% "http-verbs-play-25" % "1.0.0",
+        // empty http-core added to force eviction 
+        // as classes from this lib have been inlined in http-verbs
+        "uk.gov.hmrc" %% "http-core"          % "2.2.0",
         // force dependencies due to security flaws found in jackson-databind < 2.9.x using XRay
         "com.fasterxml.jackson.core"     % "jackson-core"            % "2.9.8",
         "com.fasterxml.jackson.core"     % "jackson-databind"        % "2.9.8",
@@ -43,7 +42,11 @@ object AppDependencies {
         // force dependencies due to security flaws found in xercesImpl 2.11.0
         // only applies to play 2.5 since it was removed from play 2.6 
         // https://github.com/playframework/playframework/blob/master/documentation/manual/releases/release26/migration26/Migration26.md#xercesimpl-removal
-        "xerces" % "xercesImpl" % "2.12.0"
+        "xerces" % "xercesImpl" % "2.12.0",
+
+        // empty http-verbs-play-25 added to force eviction
+        // as classes from this lib have been inlined in http-verbs
+        "uk.gov.hmrc" %% "http-verbs-play-25" % "1.0.0"
       ),
       play26 = Seq(
         "com.typesafe.play" %% "play-json" % "2.6.9",

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-sbt.version=0.13.16
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,4 +9,4 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.15.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.14.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "0.12.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "0.13.0")

--- a/src/main/play-26/resources/reference.conf
+++ b/src/main/play-26/resources/reference.conf
@@ -1,4 +1,4 @@
-# Copyright 2018 HM Revenue & Customs
+# Copyright 2019 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/play-26/uk/gov/hmrc/play/HeaderCarrierConverter.scala
+++ b/src/main/play-26/uk/gov/hmrc/play/HeaderCarrierConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/play-26/uk/gov/hmrc/play/connectors/Connector.scala
+++ b/src/main/play-26/uk/gov/hmrc/play/connectors/Connector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/play-26/uk/gov/hmrc/play/http/ws/WSPost.scala
+++ b/src/main/play-26/uk/gov/hmrc/play/http/ws/WSPost.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/play-26/uk/gov/hmrc/play/http/ws/WSRequest.scala
+++ b/src/main/play-26/uk/gov/hmrc/play/http/ws/WSRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/play-26/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
+++ b/src/test/play-26/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/play-26/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
+++ b/src/test/play-26/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/play-26/uk/gov/hmrc/play/http/HttpTimeoutSpec.scala
+++ b/src/test/play-26/uk/gov/hmrc/play/http/HttpTimeoutSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Because `http-verbs-play-25` in sharred section would require it's version for scala 2.12 it was moved to play-25 dependencies.

Require to merge hmrc/sbt-play-cross-compilation#1 before and update version of `sbt-play-cross-compilation`

Also require merge hmrc/http-core#5

Tested by 
```bash
#!/bin/bash
echo
echo "Testing with Play 2.5"
echo
PLAY_VERSION=2.5 sbt clean +test +publishLocal "$@"

echo
echo "Testing with Play 2.6"
echo
PLAY_VERSION=2.6 sbt clean +test +publishLocal "$@"
```