### PR TITLE
DLK-149 classes to standardise requestIDs and sessionIDs for batches

### DIFF
--- a/src/main/scala/uk/gov/hmrc/http/HeaderCarrierBatch.scala
+++ b/src/main/scala/uk/gov/hmrc/http/HeaderCarrierBatch.scala
@@ -1,0 +1,41 @@
+package uk.gov.hmrc.http
+
+import java.util.UUID
+
+import uk.gov.hmrc.http.logging.{RequestId, SessionId}
+
+/**
+  * Creates a HeaderCarrier for scheduled actions so that any audits made
+  * as part of the batch process can be tied together
+  *
+  * SessionID is used to represent the whole batch.
+  * If the batch loops through items each item should get a new HeaderCarrier so that the requestID changes
+  */
+object HeaderCarrierBatch {
+  def apply() = new HeaderCarrierBatch(s"batch-${UUID.randomUUID()}")
+}
+class HeaderCarrierBatch(sessionID:String) {
+
+  /*
+    Creates a header carrier for use in a batch process that does not process a list of items
+   */
+  def createSingleHeaderCarrier = create("batch-single")
+
+  /*
+    Creates a header carrier for the first call in a batch process that fetches a list of items to process
+   */
+  def createFirstCallHeaderCarrier = create("batch-start")
+
+  /*
+    Creates a header carrier for use in the processing of a single item in a batch
+   */
+  def createItemHeaderCarrier = create("batch-item")
+
+  private def create(prefix:String) = {
+    HeaderCarrier(
+      sessionId = Some(SessionId(sessionID)),
+      requestId = Some(RequestId(s"$prefix-${UUID.randomUUID()}"))
+    )
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/http/HeaderCarrierBatchSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/http/HeaderCarrierBatchSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.http
+
+import org.scalatest.{Matchers, WordSpec}
+import play.api.libs.json.{JsString, Json}
+
+class HeaderCarrierBatchSpec extends WordSpec with Matchers {
+  "HeaderCarrierBatch" should {
+
+    "give sessionIDs a batch- prefix" in {
+      HeaderCarrierBatch().createFirstCallHeaderCarrier.sessionId.get.value should startWith("batch-")
+    }
+
+    "give item requestIDs a batch-item- prefix" in {
+      HeaderCarrierBatch().createItemHeaderCarrier.requestId.get.value should startWith("batch-item-")
+    }
+
+    "give first call requestIDs a batch-start- prefix" in {
+      HeaderCarrierBatch().createFirstCallHeaderCarrier.requestId.get.value should startWith("batch-start-")
+    }
+
+    "give single call requestIDs a batch-single- prefix" in {
+      HeaderCarrierBatch().createSingleHeaderCarrier.requestId.get.value should startWith("batch-single-")
+    }
+
+    "create a fresh sessionID each time" in {
+      HeaderCarrierBatch().createFirstCallHeaderCarrier.sessionId should not equal
+        HeaderCarrierBatch().createFirstCallHeaderCarrier.sessionId
+    }
+
+    "create a fresh requestID for each item" in {
+      val hcb = HeaderCarrierBatch()
+      val requestIDs = (1 to 3).map { i => hcb.createItemHeaderCarrier }
+      requestIDs.toSet.size shouldBe requestIDs.size
+    }
+
+  }
+}


### PR DESCRIPTION
It is important that associated audit events can be tied together with
requestID even in the case of scheduled tasks.

Frontend HTTP requests are given a requestID which is then added to the
HeaderCarrier so that all subsequent calls forward the requestID for use
in audits.

This code provideds a standardised way to create a HeaderCarrier
for use in batch processes so that any http calls the batch service makes
pass on a requestID and sessionID for use in any audit events created by
those services.