### PR TITLE
BDOG-792 remove old ws.timeout configuration (which http-verbs didn't…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,14 +54,25 @@ lazy val httpVerbs = Project("http-verbs", file("http-verbs"))
     crossScalaVersions := Seq(scala2_11, scala2_12)
   )
 
+def sharedSources = Seq(
+  Compile / unmanagedSourceDirectories   += baseDirectory.value / "../http-verbs-common/src/main/scala",
+  Compile / unmanagedResourceDirectories += baseDirectory.value / "../http-verbs-common/src/main/resources",
+  Test    / unmanagedSourceDirectories   += baseDirectory.value / "../http-verbs-common/src/test/scala",
+  Test    / unmanagedResourceDirectories += baseDirectory.value / "../http-verbs-common/src/test/resources",
+)
+
+def copySources(module: Project) = Seq(
+  Compile / scalaSource := (module / Compile / scalaSource).value,
+  Compile / resources   := (module / Compile / resources  ).value,
+  Test    / scalaSource := (module / Test    / scalaSource).value,
+  Test    / resources   := (module / Test    / resources  ).value
+)
+
 lazy val httpVerbsPlay25 = Project("http-verbs-play-25", file("http-verbs-play-25"))
   .enablePlugins(SbtAutoBuildPlugin, SbtArtifactory)
   .settings(
     commonSettings,
-    Compile / unmanagedSourceDirectories   += baseDirectory.value / "../http-verbs-common/src/main/scala",
-    Compile / unmanagedResourceDirectories += baseDirectory.value / "../http-verbs-common/src/main/resources",
-    Test    / unmanagedSourceDirectories   += baseDirectory.value / "../http-verbs-common/src/test/scala",
-    Test    / unmanagedResourceDirectories += baseDirectory.value / "../http-verbs-common/src/test/resources",
+    sharedSources,
     crossScalaVersions := Seq(scala2_11),
     libraryDependencies ++= AppDependencies.coreCompileCommon ++
       AppDependencies.coreCompilePlay25 ++
@@ -75,15 +86,12 @@ lazy val httpVerbsPlay26 = Project("http-verbs-play-26", file("http-verbs-play-2
   .enablePlugins(SbtAutoBuildPlugin, SbtArtifactory)
   .settings(
     commonSettings,
+    sharedSources,
     crossScalaVersions := Seq(scala2_11, scala2_12),
     libraryDependencies ++= AppDependencies.coreCompileCommon ++
       AppDependencies.coreCompilePlay26 ++
       AppDependencies.coreTestCommon ++
       AppDependencies.coreTestPlay26,
-    Compile / unmanagedSourceDirectories   += baseDirectory.value / "../http-verbs-common/src/main/scala",
-    Compile / unmanagedResourceDirectories += baseDirectory.value / "../http-verbs-common/src/main/resources",
-    Test    / unmanagedSourceDirectories   += baseDirectory.value / "../http-verbs-common/src/test/scala",
-    Test    / unmanagedResourceDirectories += baseDirectory.value / "../http-verbs-common/src/test/resources",
     Test / fork := true // akka is not unloaded properly, which can affect other tests
   )
   .dependsOn(httpVerbs)
@@ -93,16 +101,12 @@ lazy val httpVerbsPlay27 = Project("http-verbs-play-27", file("http-verbs-play-2
   .settings(
     commonSettings,
     crossScalaVersions := Seq(scala2_11, scala2_12),
+    sharedSources,
+    copySources(httpVerbsPlay26),
     libraryDependencies ++= AppDependencies.coreCompileCommon ++
       AppDependencies.coreCompilePlay27 ++
       AppDependencies.coreTestCommon ++
       AppDependencies.coreTestPlay27,
-    Compile / unmanagedSourceDirectories   += baseDirectory.value / "../http-verbs-common/src/main/scala",
-    Compile / unmanagedResourceDirectories += baseDirectory.value / "../http-verbs-common/src/main/resources",
-    Test    / unmanagedSourceDirectories   += baseDirectory.value / "../http-verbs-common/src/test/scala",
-    Test    / unmanagedResourceDirectories += baseDirectory.value / "../http-verbs-common/src/test/resources",
-    Compile / scalaSource := (httpVerbsPlay26 / Compile / scalaSource).value,
-    Test    / scalaSource := (httpVerbsPlay26 / Test    / scalaSource).value,
     Test    / fork := true // akka is not unloaded properly, which can affect other tests
   )
   .dependsOn(httpVerbs)

--- a/http-verbs-play-25/src/main/resources/reference.conf
+++ b/http-verbs-play-25/src/main/resources/reference.conf
@@ -12,5 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-play.ws.timeout.request = 20000    #20 secs
-play.ws.timeout.connection = 6000  #6 secs
+httpHeadersWhitelist = []

--- a/http-verbs-play-26/src/main/resources/reference.conf
+++ b/http-verbs-play-26/src/main/resources/reference.conf
@@ -12,6 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-play.ws.timeout.request = 20 seconds
-play.ws.timeout.connection = 6 seconds
 httpHeadersWhitelist = []

--- a/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/HeaderCarrierConverter.scala
+++ b/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/HeaderCarrierConverter.scala
@@ -124,7 +124,7 @@ trait HeaderCarrierConverter {
   }
 
   private def whitelistedHeaders: Seq[String] =
-    configuration.getOptional[Seq[String]]("httpHeadersWhitelist").getOrElse(Seq())
+    configuration.get[Seq[String]]("httpHeadersWhitelist")
 
   protected def configuration: Configuration
 


### PR DESCRIPTION
… own anyway). Fix reference.conf for play 2.7 and rely on when reading httpHeadersWhitelist.

- build for Play 2.7 was missing the reference.conf
- there was a default value in both code and reference.conf (the point of reference.conf is to avoid default values in code)
- Added httpHeadersWhitelist to reference.conf for Play 2.5 for symmetry (although it still needs a default in case it can't find a running application)

would be nice to rename httpHeadersWhitelist to take an `httpverbs.` prefix to indicate the owner of the configuration, but this is widely used now.