### PR TITLE
GG-5013 - remove deprecated session attribute names AFTER 1st Oct 2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ It encapsulates some common concerns for calling other HTTP services on the HMRC
 
 ### Version 12.0.0
 
+#### SessionKeys
+The fields `authProvider` ('ap'), `userId` and `token` are no longer available in the session and these names have been removed from SessionKeys object.
+
 #### HeaderCarrier
 The fields `token` and `userId` are no longer available in the session and so have been removed from HeaderCarrier
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ It encapsulates some common concerns for calling other HTTP services on the HMRC
 
 ## Migration
 
+### Version 12.0.0
+
+#### HeaderCarrier
+The fields `token` and `userId` are no longer available in the session and so have been removed from HeaderCarrier
+
 ### Version 11.0.0
 
 #### HttpReads

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ val silencerVersion = "1.4.4"
 
 lazy val commonSettings = Seq(
   organization := "uk.gov.hmrc",
-  majorVersion := 11,
+  majorVersion := 12,
   makePublicallyAvailableOnBintray := true,
   resolvers := Seq(
     Resolver.bintrayRepo("hmrc", "releases"),

--- a/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HeaderCarrier.scala
+++ b/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HeaderCarrier.scala
@@ -24,8 +24,6 @@ case class Token(value: String) extends AnyVal
 
 case class HeaderCarrier(
   authorization: Option[Authorization]       = None,
-  userId: Option[UserId]                     = None,
-  token: Option[Token]                       = None,
   forwarded: Option[ForwardedFor]            = None,
   sessionId: Option[SessionId]               = None,
   requestId: Option[RequestId]               = None,
@@ -54,7 +52,6 @@ case class HeaderCarrier(
       requestId.map(rid => names.xRequestId  -> rid.value),
       sessionId.map(sid => names.xSessionId  -> sid.value),
       forwarded.map(f => names.xForwardedFor -> f.value),
-      token.map(t => names.token             -> t.value),
       Some(names.xRequestChain -> requestChain.value),
       authorization.map(auth => names.authorisation -> auth.value),
       trueClientIp.map(HeaderNames.trueClientIp         -> _),

--- a/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HeaderCarrier.scala
+++ b/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HeaderCarrier.scala
@@ -18,10 +18,6 @@ package uk.gov.hmrc.http
 
 import uk.gov.hmrc.http.logging._
 
-case class UserId(value: String) extends AnyVal
-
-case class Token(value: String) extends AnyVal
-
 case class HeaderCarrier(
   authorization: Option[Authorization]       = None,
   forwarded: Option[ForwardedFor]            = None,

--- a/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HeaderNames.scala
+++ b/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HeaderNames.scala
@@ -34,7 +34,6 @@ object HeaderNames {
   val xRequestChain         = "X-Request-Chain"
   val trueClientIp          = "True-Client-IP"
   val trueClientPort        = "True-Client-Port"
-  val token                 = "token"
   val surrogate             = "Surrogate"
   val otacAuthorization     = "Otac-Authorization"
   val googleAnalyticTokenId = "ga-token"
@@ -51,7 +50,6 @@ object HeaderNames {
     xRequestChain,
     trueClientIp,
     trueClientPort,
-    token,
     surrogate,
     otacAuthorization,
     googleAnalyticTokenId,

--- a/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HeaderNames.scala
+++ b/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HeaderNames.scala
@@ -67,21 +67,16 @@ object CookieNames {
 
 object SessionKeys {
   val sessionId = "sessionId"
-  val userId    = "userId"
-  @deprecated("To be removed. Use internal services lookup instead", "2016-06-24")
+  @deprecated("Use auth-client /v2/Retrievals instead", "2016-06-24")
   val name = "name"
-  @deprecated("To be removed. Use internal services lookup instead", "2016-06-24")
+  @deprecated("Use auth-client /v2/Retrievals instead", "2016-06-24")
   val email = "email"
-  @deprecated("To be removed. Use internal services lookup instead", "2016-06-24")
+  @deprecated("Use auth-client /v2/Retrievals instead", "2016-06-24")
   val agentName = "agentName"
-  @deprecated("Use internal services lookup instead", "2016-06-24")
-  val token     = "token"
   val authToken = "authToken"
   val otacToken = "otacToken"
-  @deprecated("Use internal services lookup instead", "2016-06-24")
+  @deprecated("Use auth-client /v2/Retrievals instead", "2016-06-24")
   val affinityGroup = "affinityGroup"
-  @deprecated("Use internal services lookup instead", "2016-06-24")
-  val authProvider         = "ap"
   val lastRequestTimestamp = "ts"
   val redirect             = "login_redirect"
   val npsVersion           = "nps-version"

--- a/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpVerbSpec.scala
+++ b/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpVerbSpec.scala
@@ -38,7 +38,6 @@ class HttpVerbSpec extends AnyWordSpecLike with Matchers with MockitoSugar with 
         authorization = Some(Authorization("auth")),
         sessionId     = Some(SessionId("session")),
         requestId     = Some(RequestId("request")),
-        token         = Some(Token("token")),
         forwarded     = Some(ForwardedFor("forwarded"))
       )
 

--- a/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/HeaderCarrierConverter.scala
+++ b/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/HeaderCarrierConverter.scala
@@ -63,8 +63,6 @@ object HeaderCarrierConverter {
   private def fromHeaders(headers: Headers, requestHeader: Option[RequestHeader]): HeaderCarrier =
     HeaderCarrier(
       headers.get(HeaderNames.authorisation).map(Authorization),
-      None,
-      headers.get(HeaderNames.token).map(Token),
       forwardedFor(headers),
       headers.get(HeaderNames.xSessionId).map(SessionId),
       headers.get(HeaderNames.xRequestId).map(RequestId),
@@ -83,8 +81,6 @@ object HeaderCarrierConverter {
   private def fromSession(headers: Headers, cookies: Cookies, requestHeader: Option[RequestHeader], s: Session): HeaderCarrier =
     HeaderCarrier(
       s.get(SessionKeys.authToken).map(Authorization),
-      s.get(SessionKeys.userId).map(UserId),
-      s.get(SessionKeys.token).map(Token),
       forwardedFor(headers),
       getSessionId(s, headers).map(SessionId),
       headers.get(HeaderNames.xRequestId).map(RequestId),

--- a/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
+++ b/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
@@ -44,14 +44,12 @@ class ConnectorSpec extends AnyWordSpecLike with Matchers {
       s"add expected headers to the request using the ${p.builderName}" in p.setup {
         val testAuthorisation = Authorization("someauth")
         val forwarded         = ForwardedFor("forwarded")
-        val token             = Token("token")
         val sessionId         = SessionId("session")
         val requestId         = RequestId("requestId")
         val deviceID          = "deviceIdTest"
 
         val carrier: HeaderCarrier = HeaderCarrier(
           authorization = Some(testAuthorisation),
-          token         = Some(token),
           forwarded     = Some(forwarded),
           sessionId     = Some(sessionId),
           requestId     = Some(requestId),
@@ -62,7 +60,6 @@ class ConnectorSpec extends AnyWordSpecLike with Matchers {
         val request = p.builder.buildRequest("authBase")(carrier)
         request.headers.get(HeaderNames.authorisation).flatMap(_.headOption) shouldBe Some(testAuthorisation.value)
         request.headers.get(HeaderNames.xForwardedFor).flatMap(_.headOption) shouldBe Some(forwarded.value)
-        request.headers.get(HeaderNames.token).flatMap(_.headOption)         shouldBe Some(token.value)
         request.headers.get(HeaderNames.xSessionId).flatMap(_.headOption)    shouldBe Some(sessionId.value)
         request.headers.get(HeaderNames.xRequestId).flatMap(_.headOption)    shouldBe Some(requestId.value)
         request.headers.get(HeaderNames.deviceID).flatMap(_.headOption)      shouldBe Some(deviceID)

--- a/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
+++ b/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
@@ -106,18 +106,6 @@ class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers {
       hc.nsStamp shouldBe System.nanoTime() +- 5.seconds.toNanos
     }
 
-    "find the userId from the session" in {
-      HeaderCarrierConverter
-        .fromHeadersAndSession(headers(), Some(Session(Map(SessionKeys.userId -> "beeblebrox"))))
-        .userId shouldBe Some(UserId("beeblebrox"))
-    }
-
-    "find the token from the session" in {
-      HeaderCarrierConverter
-        .fromHeadersAndSession(headers(), Some(Session(Map(SessionKeys.token -> "THE_ONE_RING"))))
-        .token shouldBe Some(Token("THE_ONE_RING"))
-    }
-
     "find the authorization from the session" in {
       HeaderCarrierConverter
         .fromHeadersAndSession(headers(), Some(Session(Map(SessionKeys.authToken -> "let me in!"))))

--- a/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/HeaderCarrierConverter.scala
+++ b/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/HeaderCarrierConverter.scala
@@ -72,8 +72,6 @@ trait HeaderCarrierConverter {
   private def fromHeaders(headers: Headers, requestHeader: Option[RequestHeader]): HeaderCarrier =
     HeaderCarrier(
       authorization    = headers.get(HeaderNames.authorisation).map(Authorization),
-      userId           = None,
-      token            = headers.get(HeaderNames.token).map(Token),
       forwarded        = forwardedFor(headers),
       sessionId        = headers.get(HeaderNames.xSessionId).map(SessionId),
       requestId        = headers.get(HeaderNames.xRequestId).map(RequestId),
@@ -96,8 +94,6 @@ trait HeaderCarrierConverter {
     s: Session): HeaderCarrier =
     HeaderCarrier(
       authorization    = s.get(SessionKeys.authToken).map(Authorization),
-      userId           = s.get(SessionKeys.userId).map(UserId),
-      token            = s.get(SessionKeys.token).map(Token),
       forwarded        = forwardedFor(headers),
       sessionId        = getSessionId(s, headers).map(SessionId),
       requestId        = headers.get(HeaderNames.xRequestId).map(RequestId),

--- a/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
+++ b/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
@@ -34,7 +34,6 @@ class ConnectorSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
       s"add expected headers to the request" in {
         val testAuthorisation = Authorization("someauth")
         val forwarded         = ForwardedFor("forwarded")
-        val token             = Token("token")
         val sessionId         = SessionId("session")
         val requestId         = RequestId("requestId")
         val deviceID          = "deviceIdTest"

--- a/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
+++ b/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
@@ -41,7 +41,6 @@ class ConnectorSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
 
         val carrier: HeaderCarrier = HeaderCarrier(
           authorization = Some(testAuthorisation),
-          token         = Some(token),
           forwarded     = Some(forwarded),
           sessionId     = Some(sessionId),
           requestId     = Some(requestId),
@@ -52,7 +51,6 @@ class ConnectorSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
         val request = builder.buildRequest("http://auth.base")(carrier)
         request.headers.get(HeaderNames.authorisation).flatMap(_.headOption) shouldBe Some(testAuthorisation.value)
         request.headers.get(HeaderNames.xForwardedFor).flatMap(_.headOption) shouldBe Some(forwarded.value)
-        request.headers.get(HeaderNames.token).flatMap(_.headOption)         shouldBe Some(token.value)
         request.headers.get(HeaderNames.xSessionId).flatMap(_.headOption)    shouldBe Some(sessionId.value)
         request.headers.get(HeaderNames.xRequestId).flatMap(_.headOption)    shouldBe Some(requestId.value)
         request.headers.get(HeaderNames.deviceID).flatMap(_.headOption)      shouldBe Some(deviceID)

--- a/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
+++ b/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
@@ -110,17 +110,6 @@ class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers with Befo
       hc.nsStamp shouldBe System.nanoTime() +- 5.seconds.toNanos
     }
 
-    "find the userId from the session" in {
-      HeaderCarrierConverter
-        .fromHeadersAndSession(headers(), Some(Session(Map(SessionKeys.userId -> "beeblebrox"))))
-        .userId shouldBe Some(UserId("beeblebrox"))
-    }
-
-    "find the token from the session" in {
-      HeaderCarrierConverter
-        .fromHeadersAndSession(headers(), Some(Session(Map(SessionKeys.token -> "THE_ONE_RING"))))
-        .token shouldBe Some(Token("THE_ONE_RING"))
-    }
 
     "find the authorization from the session" in {
       HeaderCarrierConverter


### PR DESCRIPTION
This shouldn't be merged until after 1st October 2020, see ticket GG-5013