### PR TITLE
BDOG-1104: Spike PR - DO NOT MERGE

### DIFF
--- a/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HttpGet.scala
+++ b/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HttpGet.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.http
 
+import java.net.URL
+
 import uk.gov.hmrc.http.HttpVerbs.{GET => GET_VERB}
 import uk.gov.hmrc.http.hooks.HttpHooks
 import uk.gov.hmrc.http.logging.ConnectionTracing
@@ -25,15 +27,15 @@ import scala.concurrent.{ExecutionContext, Future}
 trait HttpGet extends CoreGet with GetHttpTransport with HttpVerb with ConnectionTracing with HttpHooks with Retries {
 
   override def GET[A](
-    urlBuilder: UrlBuilder,
+    url: URL,
     headers: Seq[(String, String)])(implicit rds: HttpReads[A], hc: HeaderCarrier, ec: ExecutionContext): Future[A] = {
 
-    val url = urlBuilder.toUrl.toString
+    val stringUrl = url.toString
 
-    withTracing(GET_VERB, url) {
-      val httpResponse = retry(GET_VERB, url)(doGet(url, headers = headers))
-      executeHooks(url, GET_VERB, None, httpResponse)
-      mapErrors(GET_VERB, url, httpResponse).map(response => rds.read(GET_VERB, url, response))
+    withTracing(GET_VERB, stringUrl) {
+      val httpResponse = retry(GET_VERB, stringUrl)(doGet(stringUrl, headers = headers))
+      executeHooks(stringUrl, GET_VERB, None, httpResponse)
+      mapErrors(GET_VERB, stringUrl, httpResponse).map(response => rds.read(GET_VERB, stringUrl, response))
     }
   }
 }

--- a/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HttpTransport.scala
+++ b/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HttpTransport.scala
@@ -16,12 +16,9 @@
 
 package uk.gov.hmrc.http
 
-import java.net.{URI, URL, URLEncoder}
-import java.nio.charset.StandardCharsets.UTF_8
+import java.net.URL
 
-import play.api.Logger
 import play.api.libs.json.Writes
-import play.utils.UriEncoding
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -105,76 +102,42 @@ trait HttpTransport
     with PutHttpTransport
     with PostHttpTransport {}
 
-class UrlBuilder private (baseUrl: String, queryParams: Seq[(String, String)], fragment: Option[String]) {
-
-  if(baseUrl.contains("?")){
-    Logger(getClass).warn("Passing params in baseUrl is deprecated now. Please use builder methods on UrlBuilder to add query parameters")
-  }
-
-  if(baseUrl.contains("#")){
-    Logger(getClass).warn("Passing fragments in baseUrl is deprecated now. Please use builder methods on UrlBuilder to add fragment")
-  }
-
-  def addQueryParams(queryParameters: Seq[(String, String)]): UrlBuilder =
-    new UrlBuilder(baseUrl, queryParams = queryParams ++ queryParameters, fragment)
-  def addQueryParam(queryParam: (String, String)): UrlBuilder          = addQueryParams(Seq(queryParam))
-  def withFragment(fragment: String): UrlBuilder                       = new UrlBuilder(baseUrl, queryParams, fragment = Some(fragment))
-  def addPath(path: String): UrlBuilder = {
-    if(path.isEmpty) this else
-    new UrlBuilder(s"$baseUrl/${encodeUri(path)}", queryParams, fragment)
-  }
-
-  private val uri = new URI(baseUrl)
-
-  def toUrl: URL = {
-
-    val allQueryParams = Option(uri.getQuery).getOrElse("&").split("&").map { param =>
-      val keyValue = param.split("=", 2)
-      keyValue(0) -> keyValue(1)
-    }.toSeq ++ queryParams
-
-    val encodeQueryParams = allQueryParams
-      .map {
-        case (k, v) => s"${encodeQuery(k)}=${encodeQuery(v)}"
-      }
-
-    val queryParamPrefix = if(encodeQueryParams.nonEmpty) "?" else ""
-
-    val encodeQueryParamString = encodeQueryParams.mkString(queryParamPrefix, "&", "")
-
-    val encodedFragment = fragment.orElse(Option(uri.getFragment)).map(encodeUri).getOrElse("")
-
-    val path = baseUrl.takeWhile(_ != '?')
-
-    new URL(s"$path$encodeQueryParamString$encodedFragment")
-  }
-
-  private def encodeUri(input: String) =  UriEncoding.encodePathSegment(input, UTF_8)
-  private def encodeQuery(input: String) =  URLEncoder.encode(input, UTF_8.toString)
-}
-
-object UrlBuilder {
-  def apply(baseUrl: String) = new UrlBuilder(baseUrl, Seq.empty, None)
-}
-
 trait CoreGet {
   def GET[A](
-    urlBuilder: UrlBuilder,
-    headers: Seq[(String, String)])(implicit rds: HttpReads[A], hc: HeaderCarrier, ec: ExecutionContext): Future[A]
+    url: URL,
+    headers: Seq[(String, String)] = Seq.empty)(implicit rds: HttpReads[A], hc: HeaderCarrier, ec: ExecutionContext): Future[A]
 
-  def GET[A](url: String, queryParams: Seq[(String, String)], headers: Seq[(String, String)])(
-    implicit rds: HttpReads[A],
-    hc: HeaderCarrier,
-    ec: ExecutionContext): Future[A] = GET(UrlBuilder(url).addQueryParams(queryParams), headers)
+  def GET[A](
+    url: String,
+    queryParams: Seq[(String, String)],
+    headers: Seq[(String, String)])(
+      implicit rds: HttpReads[A],
+      hc: HeaderCarrier,
+      ec: ExecutionContext): Future[A] = {
+    if (queryParams.nonEmpty && url.contains("?")) {
+      throw new UrlValidationException(
+        url,
+        s"${this.getClass}.GET(url, queryParams)",
+        "Query parameters should be provided in either url or as a Seq of tuples")
+    }
+    GET(url"$url?$queryParams", headers)
+  }
 
-  def GET[A](url: String)(implicit rds: HttpReads[A], hc: HeaderCarrier, ec: ExecutionContext): Future[A] =
-    GET(UrlBuilder(url), Seq.empty)
+  def GET[A](
+    url: String)(
+      implicit rds: HttpReads[A],
+      hc: HeaderCarrier,
+      ec: ExecutionContext): Future[A] =
+    GET(url, Seq.empty, Seq.empty)
 
-  def GET[A](url: String, queryParams: Seq[(String, String)])(
-    implicit rds: HttpReads[A],
-    hc: HeaderCarrier,
-    ec: ExecutionContext): Future[A] =
-    GET(UrlBuilder(url).addQueryParams(queryParams), Seq.empty)
+  def GET[A](
+    url: String,
+    queryParams: Seq[(String, String)])(
+      implicit rds: HttpReads[A],
+      hc: HeaderCarrier,
+      ec: ExecutionContext): Future[A] =
+    GET(url, queryParams, Seq.empty)
+
 }
 
 trait CoreDelete {

--- a/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HttpTransport.scala
+++ b/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HttpTransport.scala
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 
 import play.api.Logger
 import play.api.libs.json.Writes
+import play.utils.UriEncoding
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -148,7 +149,7 @@ class UrlBuilder private (baseUrl: String, queryParams: Seq[(String, String)], f
     new URL(s"$path$encodeQueryParamString$encodedFragment")
   }
 
-  private def encodeUri(input: String) =  encodeQuery(input).replaceAllLiterally("+", "%20")
+  private def encodeUri(input: String) =  UriEncoding.encodePathSegment(input, UTF_8)
   private def encodeQuery(input: String) =  URLEncoder.encode(input, UTF_8.toString)
 }
 

--- a/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HttpTransport.scala
+++ b/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HttpTransport.scala
@@ -118,6 +118,10 @@ class UrlBuilder private (baseUrl: String, queryParams: Seq[(String, String)], f
     new UrlBuilder(baseUrl, queryParams = queryParams ++ queryParameters, fragment)
   def addQueryParam(queryParam: (String, String)): UrlBuilder          = addQueryParams(Seq(queryParam))
   def withFragment(fragment: String): UrlBuilder                       = new UrlBuilder(baseUrl, queryParams, fragment = Some(fragment))
+  def addPath(path: String): UrlBuilder = {
+    if(path.isEmpty) this else
+    new UrlBuilder(s"$baseUrl/${encodeUri(path)}", queryParams, fragment)
+  }
 
   private val uri = new URI(baseUrl)
 

--- a/http-verbs-common/src/main/scala/uk/gov/hmrc/http/package.scala
+++ b/http-verbs-common/src/main/scala/uk/gov/hmrc/http/package.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc
+
+import java.net.URL
+
+import sttp.model.UriInterpolator
+
+package object http {
+  implicit class StringContextOps(sc: StringContext){
+    def url(args: Any*) : URL = UriInterpolator.interpolate(sc, args: _*).toJavaUri.toURL
+  }
+}

--- a/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpGetSpec.scala
+++ b/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpGetSpec.scala
@@ -186,6 +186,33 @@ class HttpGetSpec
       testGet.lastUrl shouldBe expected
     }
 
+    "return a url with encoded param pairs with url builder" in {
+      val expected =
+        Some("http://test.net?email=test%2Balias%40email.com&data=%7B%22message%22%3A%22in+json+format%22%7D")
+      val testGet = new UrlTestingHttpGet()
+      testGet
+        .GET[HttpResponse](UrlBuilder("http://test.net").addQueryParams(Seq("email" -> "test+alias@email.com", "data" -> "{\"message\":\"in json format\"}")), Seq.empty)
+      testGet.lastUrl shouldBe expected
+    }
+
+    "return an encoded url when query param is in baseUrl" in {
+      val expected =
+        Some("http://test.net?email=testalias%40email.com&foo=bar&data=%7B%22message%22%3A%22in+json+format%22%7D")
+      val testGet = new UrlTestingHttpGet()
+      testGet
+        .GET[HttpResponse](UrlBuilder("http://test.net?email=testalias@email.com&foo=bar").addQueryParams(Seq("data" -> "{\"message\":\"in json format\"}")), Seq.empty)
+      testGet.lastUrl shouldBe expected
+    }
+
+    "return encoded url when query params are already encoded" in {
+      val expected =
+        Some("http://test.net?email=testalias%40email.com")
+      val testGet = new UrlTestingHttpGet()
+      testGet
+        .GET[HttpResponse](UrlBuilder("http://test.net?email=testalias%40email.com"), Seq.empty)
+      testGet.lastUrl shouldBe expected
+    }
+
     "return a url with duplicate param pairs" in {
       val expected = Some("http://test.net?one=1&two=2&one=11")
       val testGet = new UrlTestingHttpGet()
@@ -193,14 +220,6 @@ class HttpGetSpec
         .GET[HttpResponse]("http://test.net", Seq(("one", "1"), ("two", "2"), ("one", "11")))
       testGet.lastUrl shouldBe expected
     }
-
-    "raise an exception if the URL provided already has a query string" in {
-      val testGet = new UrlTestingHttpGet()
-
-      a[UrlValidationException] should be thrownBy testGet
-        .GET[HttpResponse]("http://test.net?should=not=be+here", Seq(("one", "1")))
-    }
-
 
     "be able to return plain responses provided already has Query and Header String" in {
       val response = HttpResponse(200, testBody)

--- a/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpGetSpec.scala
+++ b/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpGetSpec.scala
@@ -213,6 +213,18 @@ class HttpGetSpec
       testGet.lastUrl shouldBe expected
     }
 
+    "return encoded url when path needs encoding" in {
+      val expected =
+        Some("http://test.net/some%2Fother%2Froute%3Fa%3Dc%23/something?email=testalias%40email.com")
+      val testGet = new UrlTestingHttpGet()
+      testGet
+        .GET[HttpResponse](UrlBuilder("http://test.net")
+          .addPath("some/other/route?a=c#")
+          .addPath("something")
+          .addQueryParam("email" -> "testalias@email.com"), Seq.empty)
+      testGet.lastUrl shouldBe expected
+    }
+
     "return a url with duplicate param pairs" in {
       val expected = Some("http://test.net?one=1&two=2&one=11")
       val testGet = new UrlTestingHttpGet()

--- a/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpGetSpec.scala
+++ b/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpGetSpec.scala
@@ -177,7 +177,7 @@ class HttpGetSpec
 
     "return a url with encoded param pairs" in {
       val expected =
-        Some("http://test.net?email=test%2Balias%40email.com&data=%7B%22message%22%3A%22in+json+format%22%7D")
+        Some("http://test.net?email=test%2Balias@email.com&data=%7B%22message%22:%22in+json+format%22%7D")
       val testGet = new UrlTestingHttpGet()
       testGet
         .GET[HttpResponse](
@@ -188,40 +188,39 @@ class HttpGetSpec
 
     "return a url with encoded param pairs with url builder" in {
       val expected =
-        Some("http://test.net?email=test%2Balias%40email.com&data=%7B%22message%22%3A%22in+json+format%22%7D")
+        Some("http://test.net?email=test%2Balias@email.com&data=%7B%22message%22:%22in+json+format%22%7D")
       val testGet = new UrlTestingHttpGet()
-      testGet
-        .GET[HttpResponse](UrlBuilder("http://test.net").addQueryParams(Seq("email" -> "test+alias@email.com", "data" -> "{\"message\":\"in json format\"}")), Seq.empty)
+      val queryParams = Seq("email" -> "test+alias@email.com", "data" -> "{\"message\":\"in json format\"}")
+      testGet.GET[HttpResponse](url"http://test.net?$queryParams")
       testGet.lastUrl shouldBe expected
     }
 
     "return an encoded url when query param is in baseUrl" in {
       val expected =
-        Some("http://test.net?email=testalias%40email.com&foo=bar&data=%7B%22message%22%3A%22in+json+format%22%7D")
+        Some("http://test.net?email=testalias@email.com&foo=bar&data=%7B%22message%22:%22in+json+format%22%7D")
       val testGet = new UrlTestingHttpGet()
+      val queryParams = Seq("data" -> "{\"message\":\"in json format\"}")
       testGet
-        .GET[HttpResponse](UrlBuilder("http://test.net?email=testalias@email.com&foo=bar").addQueryParams(Seq("data" -> "{\"message\":\"in json format\"}")), Seq.empty)
+        .GET[HttpResponse](url"http://test.net?email=testalias@email.com&foo=bar&$queryParams")
       testGet.lastUrl shouldBe expected
     }
 
     "return encoded url when query params are already encoded" in {
       val expected =
-        Some("http://test.net?email=testalias%40email.com")
+        Some("http://test.net?email=test%2Balias@email.com")
       val testGet = new UrlTestingHttpGet()
       testGet
-        .GET[HttpResponse](UrlBuilder("http://test.net?email=testalias%40email.com"), Seq.empty)
+        .GET[HttpResponse](url"http://test.net?email=test%2Balias@email.com")
       testGet.lastUrl shouldBe expected
     }
 
     "return encoded url when path needs encoding" in {
       val expected =
-        Some("http://test.net/some%2Fother%2Froute%3Fa=b&c=d%23/something?email=testalias%40email.com")
+        Some("http://test.net/some%2Fother%2Froute%3Fa=b&c=d%23/something?email=testalias@email.com")
       val testGet = new UrlTestingHttpGet()
-      testGet
-        .GET[HttpResponse](UrlBuilder("http://test.net")
-          .addPath("some/other/route?a=b&c=d#")
-          .addPath("something")
-          .addQueryParam("email" -> "testalias@email.com"), Seq.empty)
+      val paths = List("some/other/route?a=b&c=d#", "something")
+      val email = "testalias@email.com"
+      testGet.GET[HttpResponse](url"http://test.net/$paths?email=$email")
       testGet.lastUrl shouldBe expected
     }
 
@@ -232,6 +231,14 @@ class HttpGetSpec
         .GET[HttpResponse]("http://test.net", Seq(("one", "1"), ("two", "2"), ("one", "11")))
       testGet.lastUrl shouldBe expected
     }
+
+    "raise an exception if the URL provided already has a query string" in {
+      val testGet = new UrlTestingHttpGet()
+
+      a[UrlValidationException] should be thrownBy testGet
+        .GET[HttpResponse]("http://test.net?should=not=be+here", Seq(("one", "1")))
+    }
+
 
     "be able to return plain responses provided already has Query and Header String" in {
       val response = HttpResponse(200, testBody)

--- a/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpGetSpec.scala
+++ b/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpGetSpec.scala
@@ -215,11 +215,11 @@ class HttpGetSpec
 
     "return encoded url when path needs encoding" in {
       val expected =
-        Some("http://test.net/some%2Fother%2Froute%3Fa%3Dc%23/something?email=testalias%40email.com")
+        Some("http://test.net/some%2Fother%2Froute%3Fa=b&c=d%23/something?email=testalias%40email.com")
       val testGet = new UrlTestingHttpGet()
       testGet
         .GET[HttpResponse](UrlBuilder("http://test.net")
-          .addPath("some/other/route?a=c#")
+          .addPath("some/other/route?a=b&c=d#")
           .addPath("something")
           .addQueryParam("email" -> "testalias@email.com"), Seq.empty)
       testGet.lastUrl shouldBe expected

--- a/http-verbs-common/src/test/scala/uk/gov/hmrc/http/RetriesSpec.scala
+++ b/http-verbs-common/src/test/scala/uk/gov/hmrc/http/RetriesSpec.scala
@@ -224,7 +224,7 @@ class RetriesSpec extends AnyWordSpecLike with Matchers with MockitoSugar with S
 
       implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
 
-      http.GET[Option[String]](url = "doesnt-matter", Seq("header" -> "foo")).futureValue shouldBe None
+      http.GET[Option[String]](url = "http://doesnt-matter", Seq("header" -> "foo")).futureValue shouldBe None
       http.failureCounter shouldBe http.maxFailures
     }
   }

--- a/http-verbs-common/src/test/scala/uk/gov/hmrc/play/test/helpers.scala
+++ b/http-verbs-common/src/test/scala/uk/gov/hmrc/play/test/helpers.scala
@@ -62,8 +62,7 @@ trait TestHttpCore extends CorePost with CoreGet with CorePut with CorePatch wit
     ???
 
   override def GET[A](
-    url: String,
-    queryParams: Seq[(String, String)],
+    url: UrlBuilder,
     headers: Seq[(String, String)])(
       implicit rds: HttpReads[A],
       hc: HeaderCarrier,

--- a/http-verbs-common/src/test/scala/uk/gov/hmrc/play/test/helpers.scala
+++ b/http-verbs-common/src/test/scala/uk/gov/hmrc/play/test/helpers.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.play.test
 
+import java.net.URL
+
 import play.api.libs.json.Writes
 import uk.gov.hmrc.http._
 
@@ -62,7 +64,7 @@ trait TestHttpCore extends CorePost with CoreGet with CorePut with CorePatch wit
     ???
 
   override def GET[A](
-    url: UrlBuilder,
+    url: URL,
     headers: Seq[(String, String)])(
       implicit rds: HttpReads[A],
       hc: HeaderCarrier,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -15,7 +15,8 @@ object AppDependencies {
     "uk.gov.hmrc" %% "http-core"          % "2.4.0",
     // force dependencies due to security flaws found in jackson-databind < 2.9.x using XRay
     "com.fasterxml.jackson.core"     % "jackson-core"            % "2.10.3",
-    "com.fasterxml.jackson.core"     % "jackson-databind"        % "2.10.3"
+    "com.fasterxml.jackson.core"     % "jackson-databind"        % "2.10.3",
+    "com.softwaremill.sttp.model" %% "core" % "1.2.0-RC5"
   )
 
   val coreCompilePlay25 = Seq(


### PR DESCRIPTION
~~Introduce another overload of method `HttpGet.GET` with UrlBuilder parameter which knows how to encode query params and fragments.~~

Introduce string interpolation mechanism to construct safe URLs. Using sttp API internally as they already have an implementation. Ensuring not exposing sttp to our clients.

Usage 
```

import uk.gov.hmrc.http._

httpclient.GET[HttpResponse](url"http://test.net/$paths?email=$email")

```

We can document the same interpolation mechanism which they have - https://sttp.softwaremill.com/en/latest/model/uri.html.

For now, I have only demonstrated how it'll be used for GET requests. We can do the same for other verbs.