### PR TITLE
APIS-5100 - Add content length header to all POSTEmpty calls

### DIFF
--- a/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/http/ws/verbs.scala
+++ b/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/http/ws/verbs.scala
@@ -25,7 +25,7 @@ trait WSPatch  extends default.WSPatch  with WSRequest
 trait WSPut    extends default.WSPut    with WSRequest
 trait WSPost   extends default.WSPost   with WSRequest {
   override def withEmptyBody(request: PlayWSRequest): PlayWSRequest =
-    request.withBody(Results.EmptyContent())
+    request.withBody(Results.EmptyContent()).withHeaders( (play.api.http.HeaderNames.CONTENT_LENGTH -> "0") )
 }
 
 trait WSHttp extends WSGet with WSPut with WSPost with WSDelete with WSPatch

--- a/http-verbs-play-25/src/test/scala/uk/gov/hmrc/http/HeadersSpec.scala
+++ b/http-verbs-play-25/src/test/scala/uk/gov/hmrc/http/HeadersSpec.scala
@@ -136,6 +136,26 @@ class HeadersSpec
             .withHeader("extra-header", equalTo("my-extra-header")))
       }
     }
+
+    "with an empty body" - {
+      "must add a content length header if none is present" in {
+        server.stubFor(
+          post(urlEqualTo("/empty"))
+            .willReturn(aResponse().withStatus(200)))
+
+        client.POSTEmpty[HttpResponse](s"http://localhost:${server.port()}/empty").futureValue
+
+        server.verify(
+          postRequestedFor(urlEqualTo("/empty"))
+            .withHeader(HeaderNames.authorisation, equalTo("authorization"))
+            .withHeader(HeaderNames.xForwardedFor, equalTo("forwarded-for"))
+            .withHeader(HeaderNames.xSessionId, equalTo("session-id"))
+            .withHeader(HeaderNames.xRequestId, equalTo("request-id"))
+            .withHeader("extra-header", equalTo("my-extra-header"))
+            .withHeader(play.api.http.HeaderNames.CONTENT_LENGTH, equalTo("0"))
+        )
+      }
+    }
   }
 
   "a get request" - {

--- a/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/http/ws/verbs.scala
+++ b/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/http/ws/verbs.scala
@@ -24,7 +24,7 @@ trait WSPatch  extends default.WSPatch  with WSRequest
 trait WSPut    extends default.WSPut    with WSRequest
 trait WSPost   extends default.WSPost   with WSRequest {
   override def withEmptyBody(request: PlayWSRequest): PlayWSRequest =
-    request.withBody(EmptyBody)
+    request.withBody(EmptyBody).addHttpHeaders((play.api.http.HeaderNames.CONTENT_LENGTH -> "0"))
 }
 
 trait WSHttp extends WSGet with WSPut with WSPost with WSDelete with WSPatch

--- a/http-verbs-play-26/src/test/scala/uk/gov/hmrc/http/HeadersSpec.scala
+++ b/http-verbs-play-26/src/test/scala/uk/gov/hmrc/http/HeadersSpec.scala
@@ -155,6 +155,26 @@ class HeadersSpec
             .withHeader("extra-header", equalTo("my-extra-header")))
       }
     }
+
+    "with an empty body" - {
+      "must add a content length header if none is present" in {
+        server.stubFor(
+          post(urlEqualTo("/empty"))
+            .willReturn(aResponse().withStatus(200)))
+
+        client.POSTEmpty[HttpResponse](s"http://localhost:${server.port()}/empty").futureValue
+
+        server.verify(
+          postRequestedFor(urlEqualTo("/empty"))
+            .withHeader(HeaderNames.authorisation, equalTo("authorization"))
+            .withHeader(HeaderNames.xForwardedFor, equalTo("forwarded-for"))
+            .withHeader(HeaderNames.xSessionId, equalTo("session-id"))
+            .withHeader(HeaderNames.xRequestId, equalTo("request-id"))
+            .withHeader("extra-header", equalTo("my-extra-header"))
+            .withHeader(play.api.http.HeaderNames.CONTENT_LENGTH, equalTo("0"))
+        )
+      }
+    }
   }
 
   "a get request" - {


### PR DESCRIPTION
- Does not try to be clever about any existing content length header as this should also be zero if present.

Co-authored-by: Pete Slater <pslater@equalexperts.com>