### PR TITLE
BDOG-1119 Make configuration non-optional and define defaults in refe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ The hosts identified as internal is configured by `internalServiceHostPatterns` 
 
 See Headers section below.
 
+#### Config is not optional
+
+`configuration` as required by some traits (`WSRequestBuilder` and `Retry`) has changed from `Option[com.typesafe.config.Config]` to `com.typesafe.config.Config`.
+
+If you don't want to provide any specific configuration (e.g. testing), then change `configuration = None` to `configuration = com.typesafe.config.ConfigFactory.load()`
+
 ### Version 12.0.0
 
 #### SessionKeys

--- a/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HeaderCarrier.scala
+++ b/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HeaderCarrier.scala
@@ -84,7 +84,7 @@ case class HeaderCarrier(
 
 object HeaderCarrier {
   case class Config(
-    internalHostPatterns    : Seq[Regex]     = Seq("^.*\\.service$".r, "^.*\\.mdtp$".r, "^localhost$".r),
+    internalHostPatterns    : Seq[Regex]     = Seq.empty,
     headersAllowlist        : Seq[String]    = Seq.empty,
     userAgent               : Option[String] = None
   )

--- a/http-verbs-common/src/main/scala/uk/gov/hmrc/play/http/ws/WSRequestBuilder.scala
+++ b/http-verbs-common/src/main/scala/uk/gov/hmrc/play/http/ws/WSRequestBuilder.scala
@@ -23,7 +23,7 @@ trait WSRequestBuilder extends Request {
 
   protected def wsClient: WSClient
 
-  protected def configuration: Option[com.typesafe.config.Config]
+  protected def configuration: com.typesafe.config.Config
 
   protected def buildRequest[A](url: String, headers: Seq[(String, String)])(implicit hc: HeaderCarrier): PlayWSRequest
 }

--- a/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpDeleteSpec.scala
+++ b/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpDeleteSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.http
 
 import akka.actor.ActorSystem
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigFactory}
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.{any, eq => is}
 import org.mockito.Mockito._
@@ -40,8 +40,8 @@ class HttpDeleteSpec extends AnyWordSpecLike with Matchers with MockitoSugar wit
     val testHook1                                   = mock[HttpHook]
     val testHook2                                   = mock[HttpHook]
     val hooks                                       = Seq(testHook1, testHook2)
-    override def configuration: Option[Config]      = None
-    override protected def actorSystem: ActorSystem = ActorSystem("test-actor-system")
+    override val configuration: Config              = ConfigFactory.load()
+    override protected val actorSystem: ActorSystem = ActorSystem("test-actor-system")
 
     def appName: String = ???
 

--- a/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpGetSpec.scala
+++ b/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpGetSpec.scala
@@ -33,7 +33,7 @@
 package uk.gov.hmrc.http
 
 import akka.actor.ActorSystem
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigFactory}
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.{any, eq => is}
 import org.mockito.Mockito._
@@ -63,9 +63,9 @@ class HttpGetSpec
     val testHook2 = mock[HttpHook]
     val hooks = Seq(testHook1, testHook2)
 
-    override def configuration: Option[Config] = None
+    override val configuration: Config = ConfigFactory.load()
 
-    override protected def actorSystem: ActorSystem = ActorSystem("test-actor-system")
+    override protected val actorSystem: ActorSystem = ActorSystem("test-actor-system")
 
     override def doGet(
       url: String,
@@ -81,9 +81,9 @@ class HttpGetSpec
     val hooks = Seq(testHook1, testHook2)
     var lastUrl: Option[String] = None
 
-    override def configuration: Option[Config] = None
+    override val configuration: Config = ConfigFactory.load()
 
-    override protected def actorSystem: ActorSystem = ActorSystem("test-actor-system")
+    override protected val actorSystem: ActorSystem = ActorSystem("test-actor-system")
 
     override def doGet(
       url: String,

--- a/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpPatchSpec.scala
+++ b/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpPatchSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.http
 
 import akka.actor.ActorSystem
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigFactory}
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.{any, eq => is}
 import org.mockito.Mockito._
@@ -41,8 +41,8 @@ class HttpPatchSpec extends AnyWordSpecLike with Matchers with CommonHttpBehavio
     val testHook1                                   = mock[HttpHook]
     val testHook2                                   = mock[HttpHook]
     val hooks                                       = Seq(testHook1, testHook2)
-    override def configuration: Option[Config]      = None
-    override protected def actorSystem: ActorSystem = ActorSystem("test-actor-system")
+    override val configuration: Config              = ConfigFactory.load()
+    override protected val actorSystem: ActorSystem = ActorSystem("test-actor-system")
 
     def doPatch[A](url: String, body: A, headers: Seq[(String, String)])(implicit rds: Writes[A], hc: HeaderCarrier, ec: ExecutionContext) =
       doPatchResult

--- a/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpPostSpec.scala
+++ b/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpPostSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.http
 
 import akka.actor.ActorSystem
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigFactory}
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.{any, eq => is}
 import org.mockito.Mockito._
@@ -41,8 +41,8 @@ class HttpPostSpec extends AnyWordSpecLike with Matchers with CommonHttpBehaviou
     val testHook1                                   = mock[HttpHook]
     val testHook2                                   = mock[HttpHook]
     val hooks                                       = Seq(testHook1, testHook2)
-    override def configuration: Option[Config]      = None
-    override protected def actorSystem: ActorSystem = ActorSystem("test-actor-system")
+    override val configuration: Config              = ConfigFactory.load()
+    override protected val actorSystem: ActorSystem = ActorSystem("test-actor-system")
 
     override def doPost[A](url: String, body: A, headers: Seq[(String, String)])(implicit rds: Writes[A], hc: HeaderCarrier, ec: ExecutionContext) =
       doPostResult

--- a/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpPutSpec.scala
+++ b/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HttpPutSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.http
 
 import akka.actor.ActorSystem
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigFactory}
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.{any, eq => is}
 import org.mockito.Mockito._
@@ -41,8 +41,8 @@ class HttpPutSpec extends AnyWordSpecLike with Matchers with CommonHttpBehaviour
     val testHook1                                   = mock[HttpHook]
     val testHook2                                   = mock[HttpHook]
     val hooks                                       = Seq(testHook1, testHook2)
-    override def configuration: Option[Config]      = None
-    override protected def actorSystem: ActorSystem = ActorSystem("test-actor-system")
+    override val configuration: Config              = ConfigFactory.load()
+    override protected val actorSystem: ActorSystem = ActorSystem("test-actor-system")
 
     override def doPutString(url: String, body: String, headers: Seq[(String, String)])(implicit hc: HeaderCarrier, ec: ExecutionContext) =
       doPutResult

--- a/http-verbs-play-25/src/main/resources/reference.conf
+++ b/http-verbs-play-25/src/main/resources/reference.conf
@@ -14,3 +14,7 @@
 
 internalServiceHostPatterns = [ "^.*\\.service$", "^.*\\.mdtp$", "^localhost$" ]
 bootstrap.http.headersAllowlist = []
+http-verbs.retries {
+  intervals = [ "500.millis", "1.second", "2.seconds", "4.seconds", "8.seconds" ]
+  ssl-engine-closed-already.enabled = false
+}

--- a/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/connectors/Connector.scala
+++ b/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/connectors/Connector.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.play.connectors
 
 import com.github.ghik.silencer.silent
+import com.typesafe.config.ConfigFactory
 import play.api.libs.ws.{WS, WSRequest}
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -25,14 +26,25 @@ trait RequestBuilder {
 }
 
 trait PlayWSRequestBuilder extends RequestBuilder {
+
+  @silent("deprecated")
+  private lazy val app =
+    play.api.Play.current
+
+  private lazy val hcConfig =
+    HeaderCarrier.Config.fromConfig(app.configuration.underlying)
+
   @silent("deprecated")
   def buildRequest(url: String)(implicit hc: HeaderCarrier): WSRequest =
-    WS.url(url)(play.api.Play.current)
-      .withHeaders(hc.headersForUrl(HeaderCarrier.Config())(url): _*)
+    WS.url(url)(app)
+      .withHeaders(hc.headersForUrl(hcConfig)(url): _*)
 }
 
 trait WSClientRequestBuilder extends RequestBuilder { this: WSClientProvider =>
+  private val hcConfig =
+    HeaderCarrier.Config.fromConfig(ConfigFactory.load())
+
   def buildRequest(url: String)(implicit hc: HeaderCarrier): WSRequest =
     client.url(url)
-      .withHeaders(hc.headersForUrl(HeaderCarrier.Config())(url): _*)
+      .withHeaders(hc.headersForUrl(hcConfig)(url): _*)
 }

--- a/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/http/ws/WSRequest.scala
+++ b/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/http/ws/WSRequest.scala
@@ -31,8 +31,8 @@ trait WSRequest extends WSRequestBuilder {
   override def wsClient: WSClient =
     WS.client(play.api.Play.current)
 
-  private lazy val config =
-    configuration.fold(HeaderCarrier.Config())(HeaderCarrier.Config.fromConfig)
+  private lazy val hcConfig =
+    HeaderCarrier.Config.fromConfig(configuration)
 
   override def buildRequest[A](
     url    : String,
@@ -40,7 +40,7 @@ trait WSRequest extends WSRequestBuilder {
   )(implicit
     hc: HeaderCarrier
   ): PlayWSRequest = {
-    val hdrs = hc.headersForUrl(config)(url) ++ headers
+    val hdrs = hc.headersForUrl(hcConfig)(url) ++ headers
 
     val duplicates = hdrs.groupBy(_._1).filter(_._2.length > 1).map(_._1)
     if (duplicates.nonEmpty)

--- a/http-verbs-play-25/src/test/scala/uk/gov/hmrc/http/HeadersSpec.scala
+++ b/http-verbs-play-25/src/test/scala/uk/gov/hmrc/http/HeadersSpec.scala
@@ -72,10 +72,10 @@ class HeadersSpec
   ).withExtraHeaders("extra-header" -> "my-extra-header")
 
   private lazy val client = new HttpGet with HttpPost with HttpDelete with HttpPatch with HttpPut with WSHttp {
-    override def wsClient: WSClient                      = app.injector.instanceOf[WSClient]
-    override protected def configuration: Option[Config] = None
-    override val hooks: Seq[HttpHook]                    = Seq.empty
-    override protected def actorSystem: ActorSystem      = ActorSystem("test-actor-system")
+    override def wsClient: WSClient                 = app.injector.instanceOf[WSClient]
+    override protected def configuration: Config    = app.configuration.underlying
+    override val hooks: Seq[HttpHook]               = Seq.empty
+    override protected def actorSystem: ActorSystem = ActorSystem("test-actor-system")
   }
 
   "a post request" when {

--- a/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
+++ b/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
@@ -24,19 +24,28 @@ import uk.gov.hmrc.http._
 import uk.gov.hmrc.http.logging.{Authorization, ForwardedFor, RequestId, SessionId}
 
 class ConnectorSpec extends AnyWordSpecLike with Matchers {
-  class TestConfig(val builderName: String, val builder: RequestBuilder, setupFunc: ((=> Any) => Any)) {
-    def setup(f:                                                                      => Any) = setupFunc(f)
+  class TestConfig(
+    val builderName: String,
+    val builder    : RequestBuilder,
+    setupFunc      : ((=> Any) => Any)
+  ) {
+    def setup(f: => Any) = setupFunc(f)
   }
 
   val withFakeApp: (=>     Any) => Any = running(FakeApplication())
   def withoutFakeApp(f: => Any)        = f
 
   val permutations = Seq(
-    new TestConfig("PlayWS Request Builder", new PlayWSRequestBuilder {}, withFakeApp),
     new TestConfig(
-      "WSClient Request Builder",
-      new WSClientRequestBuilder with DefaultWSClientProvider {},
-      withoutFakeApp)
+      builderName = "PlayWS Request Builder",
+      builder     = new PlayWSRequestBuilder {},
+      setupFunc   = withFakeApp
+    ),
+    new TestConfig(
+      builderName = "WSClient Request Builder",
+      builder     = new WSClientRequestBuilder with DefaultWSClientProvider {},
+      setupFunc   = withoutFakeApp
+    )
   )
 
   "AuthConnector.buildRequest" should {

--- a/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/http/HttpTimeoutSpec.scala
+++ b/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/http/HttpTimeoutSpec.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.play.http
 import java.net.{ServerSocket, URI}
 import java.util.concurrent.TimeoutException
 
+import com.typesafe.config.Config
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -58,7 +59,7 @@ class HttpTimeoutSpec
 
     "be gracefully timeout when no response is received within the 'timeout' frame" in {
       val http = new WSHttp with TestHttpCore {
-        override val configuration = None
+        override val configuration = fakeApplication.configuration.underlying
       }
 
       // get an unused port

--- a/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/http/ws/WsProxySpec.scala
+++ b/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/http/ws/WsProxySpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.play.http.ws
 
 import com.github.tomakehurst.wiremock.client.VerificationException
 import com.github.tomakehurst.wiremock.client.WireMock._
+import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.{BeforeAndAfterAll, OptionValues}
@@ -38,7 +39,7 @@ class WsProxySpec extends AnyWordSpecLike with Matchers with MockitoSugar with O
       val wSProxyServer = mock[WSProxyServer]
 
       object ProxiedGet extends WSProxy {
-        override val configuration = None
+        override val configuration = ConfigFactory.load()
         override def wsProxyServer = Some(wSProxyServer)
       }
 
@@ -52,7 +53,7 @@ class WsProxySpec extends AnyWordSpecLike with Matchers with MockitoSugar with O
     "still work by making the request without using a proxy server" in new Setup {
 
       object ProxiedGet extends WSProxy {
-        override val configuration = None
+        override val configuration: Config = ConfigFactory.load()
         override def wsProxyServer = None
       }
 

--- a/http-verbs-play-26/src/main/resources/reference.conf
+++ b/http-verbs-play-26/src/main/resources/reference.conf
@@ -14,3 +14,7 @@
 
 internalServiceHostPatterns = [ "^.*\\.service$", "^.*\\.mdtp$", "^localhost$" ]
 bootstrap.http.headersAllowlist = []
+http-verbs.retries {
+  intervals = [ "500.millis", "1.second", "2.seconds", "4.seconds", "8.seconds" ]
+  ssl-engine-closed-already.enabled = false
+}

--- a/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/connectors/Connector.scala
+++ b/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/connectors/Connector.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.play.connectors
 
+import com.typesafe.config.ConfigFactory
 import play.api.libs.ws.{WSClient, WSRequest}
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -25,7 +26,11 @@ trait RequestBuilder {
 
 trait WSClientRequestBuilder extends RequestBuilder {
   def client: WSClient
+
+  private val hcConfig =
+    HeaderCarrier.Config.fromConfig(ConfigFactory.load())
+
   def buildRequest(url: String)(implicit hc: HeaderCarrier): WSRequest =
     client.url(url)
-      .withHttpHeaders(hc.headersForUrl(HeaderCarrier.Config())(url): _*)
+      .withHttpHeaders(hc.headersForUrl(hcConfig)(url): _*)
 }

--- a/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/http/ws/WSRequest.scala
+++ b/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/http/ws/WSRequest.scala
@@ -24,8 +24,8 @@ trait WSRequest extends WSRequestBuilder {
 
   private val logger = Logger(getClass)
 
-  private lazy val config =
-    configuration.fold(HeaderCarrier.Config())(HeaderCarrier.Config.fromConfig)
+  private lazy val hcConfig =
+    HeaderCarrier.Config.fromConfig(configuration)
 
   override def buildRequest[A](
     url    : String,
@@ -33,7 +33,7 @@ trait WSRequest extends WSRequestBuilder {
   )(implicit
     hc: HeaderCarrier
   ): PlayWSRequest = {
-    val hdrs = hc.headersForUrl(config)(url) ++ headers
+    val hdrs = hc.headersForUrl(hcConfig)(url) ++ headers
 
     val duplicates = hdrs.groupBy(_._1).filter(_._2.length > 1).map(_._1)
     if (duplicates.nonEmpty)

--- a/http-verbs-play-26/src/test/scala/uk/gov/hmrc/http/HeadersSpec.scala
+++ b/http-verbs-play-26/src/test/scala/uk/gov/hmrc/http/HeadersSpec.scala
@@ -72,10 +72,10 @@ class HeadersSpec
   ).withExtraHeaders("extra-header" -> "my-extra-header")
 
   private lazy val client = new HttpGet with HttpPost with HttpDelete with HttpPatch with HttpPut with WSHttp {
-    override def wsClient: WSClient                      = app.injector.instanceOf[WSClient]
-    override protected def configuration: Option[Config] = None
-    override val hooks: Seq[HttpHook]                    = Seq.empty
-    override protected def actorSystem: ActorSystem      = ActorSystem("test-actor-system")
+    override def wsClient: WSClient                 = app.injector.instanceOf[WSClient]
+    override protected def configuration: Config    = app.configuration.underlying
+    override val hooks: Seq[HttpHook]               = Seq.empty
+    override protected def actorSystem: ActorSystem = ActorSystem("test-actor-system")
   }
 
   "a post request" when {

--- a/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/http/HttpTimeoutSpec.scala
+++ b/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/http/HttpTimeoutSpec.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.play.http
 import java.net.{ServerSocket, URI}
 import java.util.concurrent.TimeoutException
 
+import com.typesafe.config.Config
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -63,7 +64,7 @@ class HttpTimeoutSpec
 
       "be gracefully timeout when no response is received within the 'timeout' frame" in {
         val http = new WSHttp with TestHttpCore {
-          override val configuration = None
+          override val configuration = fakeApplication.configuration.underlying
           override val wsClient = fakeApplication.injector.instanceOf[WSClient]
         }
 


### PR DESCRIPTION
…rence.conf

The change is primarily from `def configuration: Option[Config]` to `def configuration: Config` - this will require a change in the DefaultHttpClient in bootstrap.
The benefit is that we only have to provide default values in `reference.conf`, which is visible through config explorer etc.
Currently, we have default values in code, for when `configuration = None`. This can make it harder to reason about (the value in config explorer may or may not have been applied)