### PR TITLE
BDOG 1119 - move packages and simplify HeaderCarrierConverter

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ It encapsulates some common concerns for calling other HTTP services on the HMRC
 
 #### Headers
 
+The Headers `Authorization`, `ForwardedFor`, `RequestChain`, `RequestId`, `SessionId` have been moved from package `uk.gov.hmrc.http.logging` to `uk.gov.hmrc.http`
+
 ##### External hosts
 
 Explicit headers (those modelled explicitly in the `HeaderCarrier`) are no longer forwarded to external hosts. They will have to be provided explicitly via the *VERB* methods (GET, POST etc.).

--- a/README.md
+++ b/README.md
@@ -109,20 +109,12 @@ The `HeaderCarrier` should be created with `HeaderCarrierConverter` when a reque
 E.g. for frontends:
 
 ```scala
-HeaderCarrierConverter.fromHeadersAndSessionAndRequest(
-  headers = request.headers,
-  session = Some(request.session),
-  request = Some(request)
-)
+HeaderCarrierConverter.fromRequestAndSession(request, request.session)
 ```
 and for backends:
 
 ```scala
-HeaderCarrierConverter.fromHeadersAndSessionAndRequest(
-  headers = request.headers,
-  session = None,
-  request = Some(request)
-)
+HeaderCarrierConverter.fromRequest(request)
 ```
 
 #### Propagation of headers

--- a/README.md
+++ b/README.md
@@ -106,16 +106,26 @@ Examples can be found [here](https://github.com/hmrc/http-verbs/blob/master/http
 
 The `HeaderCarrier` should be created with `HeaderCarrierConverter` when a request is available, this will ensure that the appropriate headers are forwarded to internal hosts.
 
-E.g. for frontends:
-
-```scala
-HeaderCarrierConverter.fromRequestAndSession(request, request.session)
-```
-and for backends:
+E.g. for backends:
 
 ```scala
 HeaderCarrierConverter.fromRequest(request)
 ```
+
+and for frontends:
+
+```scala
+HeaderCarrierConverter.fromRequestAndSession(request, request.session)
+```
+
+If a frontend endpoint is servicing an API call, it should probably use `fromRequest` since `fromRequestAndSession` will only look for an Authorization token in the session, and ignore any provided as a request header.
+
+For asynchronous calls, where no request is available, a new HeaderCarrier can be created with default params:
+
+```scala
+HeaderCarrier()
+```
+
 
 #### Propagation of headers
 

--- a/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HeaderCarrier.scala
+++ b/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HeaderCarrier.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.http
 import java.net.URL
 
 import org.slf4j.{Logger, LoggerFactory}
-import uk.gov.hmrc.http.logging._
+import uk.gov.hmrc.http.logging.LoggingDetails
 
 import scala.util.matching.Regex
 

--- a/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HeaderNames.scala
+++ b/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HeaderNames.scala
@@ -84,3 +84,24 @@ object SessionKeys {
   val portalRedirectUrl    = "portalRedirectUrl"
   val portalState          = "portalState"
 }
+
+
+case class Authorization(value: String) extends AnyVal
+
+case class SessionId(value: String) extends AnyVal
+
+case class RequestId(value: String) extends AnyVal
+
+case class AkamaiReputation(value: String) extends AnyVal
+
+case class RequestChain(value: String) extends AnyVal {
+  def extend = RequestChain(s"$value-${RequestChain.newComponent}")
+}
+
+object RequestChain {
+  def newComponent = (scala.util.Random.nextInt & 0xffff).toHexString
+
+  def init = RequestChain(newComponent)
+}
+
+case class ForwardedFor(value: String) extends AnyVal

--- a/http-verbs-common/src/main/scala/uk/gov/hmrc/http/logging/LoggingDetails.scala
+++ b/http-verbs-common/src/main/scala/uk/gov/hmrc/http/logging/LoggingDetails.scala
@@ -14,56 +14,86 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.http.logging
-
-import uk.gov.hmrc.http._
+package uk.gov.hmrc.http
 
 import scala.util.Random
 
-case class Authorization(value: String) extends AnyVal
+package object logging {
 
-case class SessionId(value: String) extends AnyVal
+  @deprecated("Use uk.gov.hmrc.http.Authorization instead", "2.12.0")
+  type Authorization = uk.gov.hmrc.http.Authorization
 
-case class RequestId(value: String) extends AnyVal
+  @deprecated("Use uk.gov.hmrc.http.SessionId instead", "2.12.0")
+  type SessionId = uk.gov.hmrc.http.SessionId
 
-case class AkamaiReputation(value: String) extends AnyVal
+  @deprecated("Use uk.gov.hmrc.http.SessionId instead", "2.12.0")
+  object SessionId {
+    def apply(value: String) = uk.gov.hmrc.http.SessionId(value)
+  }
 
-case class RequestChain(value: String) extends AnyVal {
-  def extend = RequestChain(s"$value-${RequestChain.newComponent}")
+  @deprecated("Use uk.gov.hmrc.http.RequestId instead", "2.12.0")
+  type RequestId = uk.gov.hmrc.http.RequestId
+
+  @deprecated("Use uk.gov.hmrc.http.RequestId instead", "2.12.0")
+  object RequestId {
+    def apply(value: String) = uk.gov.hmrc.http.RequestId(value)
+  }
+
+  @deprecated("Use uk.gov.hmrc.http.AkamaiReputation instead", "2.12.0")
+  type AkamaiReputation = uk.gov.hmrc.http.AkamaiReputation
+
+  @deprecated("Use uk.gov.hmrc.http.AkamaiReputation instead", "2.12.0")
+  object AkamaiReputation {
+    def apply(value: String) = uk.gov.hmrc.http.AkamaiReputation(value)
+  }
+
+  @deprecated("Use uk.gov.hmrc.http.RequestChain instead", "2.12.0")
+  type RequestChain = uk.gov.hmrc.http.RequestChain
+
+  @deprecated("Use uk.gov.hmrc.http.RequestChain instead", "2.12.0")
+  object RequestChain {
+    def apply(value: String) = uk.gov.hmrc.http.RequestChain(value)
+
+    def init = uk.gov.hmrc.http.RequestChain.init
+  }
+
+  @deprecated("Use uk.gov.hmrc.http.ForwardedFor instead", "2.12.0")
+  type ForwardedFor = uk.gov.hmrc.http.ForwardedFor
+
+  @deprecated("Use uk.gov.hmrc.http.ForwardedFor instead", "2.12.0")
+  object ForwardedFor {
+    def apply(value: String) = uk.gov.hmrc.http.ForwardedFor(value)
+  }
 }
 
-object RequestChain {
-  def newComponent = (Random.nextInt & 0xffff).toHexString
+package logging {
+  trait LoggingDetails {
 
-  def init = RequestChain(newComponent)
-}
+    import uk.gov.hmrc.http._
 
-case class ForwardedFor(value: String) extends AnyVal
+    def sessionId: Option[uk.gov.hmrc.http.SessionId]
 
-trait LoggingDetails {
+    def requestId: Option[uk.gov.hmrc.http.RequestId]
 
-  def sessionId: Option[SessionId]
+    def requestChain: uk.gov.hmrc.http.RequestChain
 
-  def requestId: Option[RequestId]
+    @deprecated("Authorization header is no longer included in logging", "-")
+    def authorization: Option[uk.gov.hmrc.http.Authorization]
 
-  def requestChain: RequestChain
+    def forwarded: Option[uk.gov.hmrc.http.ForwardedFor]
 
-  @deprecated("Authorization header is no longer included in logging", "-")
-  def authorization: Option[Authorization]
+    def age: Long
 
-  def forwarded: Option[ForwardedFor]
+    lazy val data: Map[String, Option[String]] = Map(
+      HeaderNames.xRequestId    -> requestId.map(_.value),
+      HeaderNames.xSessionId    -> sessionId.map(_.value),
+      HeaderNames.xForwardedFor -> forwarded.map(_.value)
+    )
 
-  def age: Long
-
-  lazy val data: Map[String, Option[String]] = Map(
-    HeaderNames.xRequestId    -> requestId.map(_.value),
-    HeaderNames.xSessionId    -> sessionId.map(_.value),
-    HeaderNames.xForwardedFor -> forwarded.map(_.value)
-  )
-
-  def mdcData: Map[String, String] =
-    for {
-      d <- data
-      v <- d._2
-    } yield (d._1, v)
+    def mdcData: Map[String, String] =
+      for {
+        d <- data
+        v <- d._2
+      } yield (d._1, v)
+  }
 }

--- a/http-verbs-common/src/main/scala/uk/gov/hmrc/http/logging/LoggingDetails.scala
+++ b/http-verbs-common/src/main/scala/uk/gov/hmrc/http/logging/LoggingDetails.scala
@@ -14,86 +14,35 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.http
+package uk.gov.hmrc.http.logging
 
 import scala.util.Random
+import uk.gov.hmrc.http.{Authorization, ForwardedFor, HeaderNames, RequestChain, RequestId, SessionId}
 
-package object logging {
+trait LoggingDetails {
 
-  @deprecated("Use uk.gov.hmrc.http.Authorization instead", "2.12.0")
-  type Authorization = uk.gov.hmrc.http.Authorization
+  def sessionId: Option[SessionId]
 
-  @deprecated("Use uk.gov.hmrc.http.SessionId instead", "2.12.0")
-  type SessionId = uk.gov.hmrc.http.SessionId
+  def requestId: Option[RequestId]
 
-  @deprecated("Use uk.gov.hmrc.http.SessionId instead", "2.12.0")
-  object SessionId {
-    def apply(value: String) = uk.gov.hmrc.http.SessionId(value)
-  }
+  def requestChain: RequestChain
 
-  @deprecated("Use uk.gov.hmrc.http.RequestId instead", "2.12.0")
-  type RequestId = uk.gov.hmrc.http.RequestId
+  @deprecated("Authorization header is no longer included in logging", "-")
+  def authorization: Option[Authorization]
 
-  @deprecated("Use uk.gov.hmrc.http.RequestId instead", "2.12.0")
-  object RequestId {
-    def apply(value: String) = uk.gov.hmrc.http.RequestId(value)
-  }
+  def forwarded: Option[ForwardedFor]
 
-  @deprecated("Use uk.gov.hmrc.http.AkamaiReputation instead", "2.12.0")
-  type AkamaiReputation = uk.gov.hmrc.http.AkamaiReputation
+  def age: Long
 
-  @deprecated("Use uk.gov.hmrc.http.AkamaiReputation instead", "2.12.0")
-  object AkamaiReputation {
-    def apply(value: String) = uk.gov.hmrc.http.AkamaiReputation(value)
-  }
+  lazy val data: Map[String, Option[String]] = Map(
+    HeaderNames.xRequestId    -> requestId.map(_.value),
+    HeaderNames.xSessionId    -> sessionId.map(_.value),
+    HeaderNames.xForwardedFor -> forwarded.map(_.value)
+  )
 
-  @deprecated("Use uk.gov.hmrc.http.RequestChain instead", "2.12.0")
-  type RequestChain = uk.gov.hmrc.http.RequestChain
-
-  @deprecated("Use uk.gov.hmrc.http.RequestChain instead", "2.12.0")
-  object RequestChain {
-    def apply(value: String) = uk.gov.hmrc.http.RequestChain(value)
-
-    def init = uk.gov.hmrc.http.RequestChain.init
-  }
-
-  @deprecated("Use uk.gov.hmrc.http.ForwardedFor instead", "2.12.0")
-  type ForwardedFor = uk.gov.hmrc.http.ForwardedFor
-
-  @deprecated("Use uk.gov.hmrc.http.ForwardedFor instead", "2.12.0")
-  object ForwardedFor {
-    def apply(value: String) = uk.gov.hmrc.http.ForwardedFor(value)
-  }
-}
-
-package logging {
-  trait LoggingDetails {
-
-    import uk.gov.hmrc.http._
-
-    def sessionId: Option[uk.gov.hmrc.http.SessionId]
-
-    def requestId: Option[uk.gov.hmrc.http.RequestId]
-
-    def requestChain: uk.gov.hmrc.http.RequestChain
-
-    @deprecated("Authorization header is no longer included in logging", "-")
-    def authorization: Option[uk.gov.hmrc.http.Authorization]
-
-    def forwarded: Option[uk.gov.hmrc.http.ForwardedFor]
-
-    def age: Long
-
-    lazy val data: Map[String, Option[String]] = Map(
-      HeaderNames.xRequestId    -> requestId.map(_.value),
-      HeaderNames.xSessionId    -> sessionId.map(_.value),
-      HeaderNames.xForwardedFor -> forwarded.map(_.value)
-    )
-
-    def mdcData: Map[String, String] =
-      for {
-        d <- data
-        v <- d._2
-      } yield (d._1, v)
-  }
+  def mdcData: Map[String, String] =
+    for {
+      d <- data
+      v <- d._2
+    } yield (d._1, v)
 }

--- a/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HeaderCarrierSpec.scala
+++ b/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HeaderCarrierSpec.scala
@@ -27,7 +27,6 @@ import org.scalatest.LoneElement
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
-import uk.gov.hmrc.http.logging.{Authorization, ForwardedFor, RequestId, SessionId}
 
 class HeaderCarrierSpec
   extends AnyWordSpecLike

--- a/http-verbs-common/src/test/scala/uk/gov/hmrc/http/examples/Examples.scala
+++ b/http-verbs-common/src/test/scala/uk/gov/hmrc/http/examples/Examples.scala
@@ -47,7 +47,6 @@ import play.api.libs.ws.WSClient
 import uk.gov.hmrc.http.examples.utils._
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.http.hooks.HttpHook
-import uk.gov.hmrc.http.logging.Authorization
 import uk.gov.hmrc.play.http.ws.WSHttp
 import uk.gov.hmrc.http.HttpReads.Implicits._
 

--- a/http-verbs-common/src/test/scala/uk/gov/hmrc/http/logging/ConnectionTracingSpec.scala
+++ b/http-verbs-common/src/test/scala/uk/gov/hmrc/http/logging/ConnectionTracingSpec.scala
@@ -24,7 +24,6 @@ import org.scalatest.matchers.should.Matchers
 import org.slf4j.Logger
 import uk.gov.hmrc.http._
 
-
 import scala.util.{Failure, Success}
 
 class ConnectionTracingSpec extends AnyWordSpecLike with Matchers with MockitoSugar with BeforeAndAfterEach {

--- a/http-verbs-common/src/test/scala/uk/gov/hmrc/http/logging/ConnectionTracingSpec.scala
+++ b/http-verbs-common/src/test/scala/uk/gov/hmrc/http/logging/ConnectionTracingSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.matchers.should.Matchers
 import org.slf4j.Logger
 import uk.gov.hmrc.http._
 
+
 import scala.util.{Failure, Success}
 
 class ConnectionTracingSpec extends AnyWordSpecLike with Matchers with MockitoSugar with BeforeAndAfterEach {
@@ -38,9 +39,7 @@ class ConnectionTracingSpec extends AnyWordSpecLike with Matchers with MockitoSu
     reset(mockPlayLogger)
 
   "logResult" should {
-
     "log 200 as DEBUG" in {
-
       val ld = new StubLoggingDetails()
 
       val httpResult = Success("response")
@@ -51,7 +50,6 @@ class ConnectionTracingSpec extends AnyWordSpecLike with Matchers with MockitoSu
     }
 
     "log 404 error as INFO" in {
-
       val ld = new StubLoggingDetails()
 
       val httpResult = Failure(new NotFoundException("not found"))
@@ -62,7 +60,6 @@ class ConnectionTracingSpec extends AnyWordSpecLike with Matchers with MockitoSu
     }
 
     "log 404 upstream error as INFO" in {
-
       val ld = new StubLoggingDetails()
 
       val httpResult = Failure(UpstreamErrorResponse(message = "404 error", statusCode = 404, reportAs = 404))
@@ -73,7 +70,6 @@ class ConnectionTracingSpec extends AnyWordSpecLike with Matchers with MockitoSu
     }
 
     "log 401 upstream error as WARN" in {
-
       val ld = new StubLoggingDetails()
 
       val httpResult = Failure(UpstreamErrorResponse(message = "401 error", statusCode = 401, reportAs = 401))
@@ -84,7 +80,6 @@ class ConnectionTracingSpec extends AnyWordSpecLike with Matchers with MockitoSu
     }
 
     "log 400 error as WARN" in {
-
       val ld = new StubLoggingDetails()
 
       val httpResult = Failure(UpstreamErrorResponse(message = "400 error", statusCode = 400, reportAs = 400))
@@ -95,7 +90,6 @@ class ConnectionTracingSpec extends AnyWordSpecLike with Matchers with MockitoSu
     }
 
     "log 500 upstream error as WARN" in {
-
       val ld = new StubLoggingDetails()
 
       val httpResult = Failure(UpstreamErrorResponse(message = "500 error", statusCode = 500, reportAs = 500))
@@ -106,7 +100,6 @@ class ConnectionTracingSpec extends AnyWordSpecLike with Matchers with MockitoSu
     }
 
     "log 502 error as WARN" in {
-
       val ld = new StubLoggingDetails()
 
       val httpResult = Failure(new BadGatewayException("502 error"))
@@ -117,7 +110,6 @@ class ConnectionTracingSpec extends AnyWordSpecLike with Matchers with MockitoSu
     }
 
     "log unrecognised exception as WARN" in {
-
       val ld = new StubLoggingDetails()
 
       val httpResult = Failure(new Exception("unknown error"))
@@ -129,6 +121,8 @@ class ConnectionTracingSpec extends AnyWordSpecLike with Matchers with MockitoSu
   }
 
   private class StubLoggingDetails extends LoggingDetails {
+    import uk.gov.hmrc.http.{Authorization, ForwardedFor, RequestId, RequestChain, SessionId}
+
     override def sessionId: Option[SessionId] = Some(SessionId("sId"))
 
     override def forwarded: Option[ForwardedFor] = None

--- a/http-verbs-play-25/src/main/scala/uk/gov/hmrc/package.scala
+++ b/http-verbs-play-25/src/main/scala/uk/gov/hmrc/package.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc
+
+package play {
+
+  @deprecated("Use uk.gov.hmrc.play.http.HeaderCarrierConverter instead", "13.0.0")
+  object HeaderCarrierConverter extends uk.gov.hmrc.play.http.HeaderCarrierConverter
+}

--- a/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/HeaderCarrierConverter.scala
+++ b/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/HeaderCarrierConverter.scala
@@ -20,7 +20,6 @@ import com.github.ghik.silencer.silent
 import play.api.Play
 import play.api.mvc.{Cookies, Headers, RequestHeader, Session}
 import uk.gov.hmrc.http._
-import uk.gov.hmrc.http.logging._
 
 import scala.util.Try
 

--- a/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/connectors/Connector.scala
+++ b/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/connectors/Connector.scala
@@ -20,10 +20,12 @@ import com.github.ghik.silencer.silent
 import play.api.libs.ws.{WS, WSRequest}
 import uk.gov.hmrc.http.HeaderCarrier
 
+@deprecated("Use uk.gov.hmrc.play.http.ws.WSRequestBuilder", "13.0.0")
 trait RequestBuilder {
   def buildRequest(url: String)(implicit hc: HeaderCarrier): WSRequest
 }
 
+@deprecated("Use uk.gov.hmrc.play.http.ws.WSRequest", "13.0.0")
 trait PlayWSRequestBuilder extends RequestBuilder {
   @silent("deprecated")
   def buildRequest(url: String)(implicit hc: HeaderCarrier): WSRequest =
@@ -31,6 +33,7 @@ trait PlayWSRequestBuilder extends RequestBuilder {
       .withHeaders(hc.headersForUrl(HeaderCarrier.Config())(url): _*)
 }
 
+@deprecated("Use uk.gov.hmrc.play.http.ws.WSRequest", "13.0.0")
 trait WSClientRequestBuilder extends RequestBuilder { this: WSClientProvider =>
   def buildRequest(url: String)(implicit hc: HeaderCarrier): WSRequest =
     client.url(url)

--- a/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/connectors/WSClientProvider.scala
+++ b/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/connectors/WSClientProvider.scala
@@ -21,10 +21,12 @@ import akka.stream.ActorMaterializer
 import play.api.libs.ws.WSClient
 import play.api.libs.ws.ahc.{AhcConfigBuilder, AhcWSClient}
 
+@deprecated("Use uk.gov.hmrc.play.http.ws.WSRequest and inject WSClient", "13.0.0")
 trait WSClientProvider {
   implicit val client: WSClient
 }
 
+@deprecated("Use uk.gov.hmrc.play.http.ws.WSRequest and inject WSClient", "13.0.0")
 trait DefaultWSClientProvider extends WSClientProvider {
   val builder    = new AhcConfigBuilder()
   val ahcBuilder = builder.configure()

--- a/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/http/HeaderCarrierConverter.scala
+++ b/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/http/HeaderCarrierConverter.scala
@@ -16,8 +16,6 @@
 
 package uk.gov.hmrc.play.http
 
-import com.github.ghik.silencer.silent
-import play.api.Play
 import play.api.mvc.{Cookies, Headers, RequestHeader, Session}
 import uk.gov.hmrc.http._
 
@@ -25,37 +23,37 @@ import scala.util.Try
 
 trait HeaderCarrierConverter {
 
-  def fromRequest(request: RequestHeader) =
-    fromHeaders(
+  def fromRequest(request: RequestHeader): HeaderCarrier =
+    buildHeaderCarrier(
       headers = request.headers,
+      session = None,
       request = Some(request)
     )
 
-  def fromRequestAndSession(request: RequestHeader, session: Session) =
-    fromSession(
+  def fromRequestAndSession(request: RequestHeader, session: Session): HeaderCarrier =
+    buildHeaderCarrier(
       headers = request.headers,
-      cookies = Cookies.fromCookieHeader(request.headers.get(play.api.http.HeaderNames.COOKIE)),
-      request = Some(request),
-      session = session
+      session = Some(session),
+      request = Some(request)
     )
 
-  @deprecated("Use fromRequest or fromRequestAndSession as appropiate", "13.0.0")
-  def fromHeadersAndSession(headers: Headers, session: Option[Session] = None) =
-    fromHeadersAndSessionAndRequest(headers, session, None)
+  @deprecated("Use fromRequest or fromRequestAndSession as appropriate", "13.0.0")
+  def fromHeadersAndSession(headers: Headers, session: Option[Session] = None): HeaderCarrier =
+    buildHeaderCarrier(headers, session, request = None)
 
-  @deprecated("Use fromRequest or fromRequestAndSession as appropiate", "13.0.0")
-  def fromHeadersAndSessionAndRequest(headers: Headers, session: Option[Session] = None, request: Option[RequestHeader] = None) = {
-    lazy val cookies: Cookies = Cookies.fromCookieHeader(headers.get(play.api.http.HeaderNames.COOKIE))
-    session.fold(fromHeaders(headers, request)) {
-      fromSession(headers, cookies, request, _)
-    }
-  }
+  @deprecated("Use fromRequest or fromRequestAndSession as appropriate", "13.0.0")
+  def fromHeadersAndSessionAndRequest(
+    headers: Headers,
+    session: Option[Session]       = None,
+    request: Option[RequestHeader] = None
+  ): HeaderCarrier =
+    buildHeaderCarrier(headers, session, request)
 
-  def buildRequestChain(currentChain: Option[String]): RequestChain =
+  private def buildRequestChain(currentChain: Option[String]): RequestChain =
     currentChain
       .fold(RequestChain.init)(chain => RequestChain(chain).extend)
 
-  def requestTimestamp(headers: Headers): Long =
+  private def requestTimestamp(headers: Headers): Long =
     headers
       .get(HeaderNames.xRequestTimestamp)
       .flatMap(tsAsString => Try(tsAsString.toLong).toOption)
@@ -63,44 +61,20 @@ trait HeaderCarrierConverter {
 
   val Path = "path"
 
-  private def getSessionId(session: Session, headers: Headers): Option[String] =
-    session
-      .get(SessionKeys.sessionId)
-      .fold(headers.get(HeaderNames.xSessionId))(Some(_))
-
-  private def getDeviceId(cookies: Cookies, headers: Headers): Option[String] =
-    cookies
-      .get(CookieNames.deviceID)
-      .fold(headers.get(HeaderNames.deviceID))(cookie => Some(cookie.value))
-
-  private def fromHeaders(headers: Headers, request: Option[RequestHeader]): HeaderCarrier =
-    HeaderCarrier(
-      authorization    = headers.get(HeaderNames.authorisation).map(Authorization),
-      forwarded        = forwardedFor(headers),
-      sessionId        = headers.get(HeaderNames.xSessionId).map(SessionId),
-      requestId        = headers.get(HeaderNames.xRequestId).map(RequestId),
-      requestChain     = buildRequestChain(headers.get(HeaderNames.xRequestChain)),
-      nsStamp          = requestTimestamp(headers),
-      extraHeaders     = Seq.empty,
-      trueClientIp     = headers.get(HeaderNames.trueClientIp),
-      trueClientPort   = headers.get(HeaderNames.trueClientPort),
-      gaToken          = headers.get(HeaderNames.googleAnalyticTokenId),
-      gaUserId         = headers.get(HeaderNames.googleAnalyticUserId),
-      deviceID         = headers.get(HeaderNames.deviceID),
-      akamaiReputation = headers.get(HeaderNames.akamaiReputation).map(AkamaiReputation),
-      otherHeaders     = otherHeaders(headers, request)
-    )
-
-  private def fromSession(
+  private def buildHeaderCarrier(
     headers: Headers,
-    cookies: Cookies,
-    request: Option[RequestHeader],
-    session: Session
-  ): HeaderCarrier =
+    session: Option[Session],
+    request: Option[RequestHeader]
+  ): HeaderCarrier = {
+    lazy val cookies: Cookies = Cookies.fromCookieHeader(headers.get(play.api.http.HeaderNames.COOKIE))
     HeaderCarrier(
-      authorization    = session.get(SessionKeys.authToken).map(Authorization),
+      authorization    = // Note, if a session is provided, any Authorization header in the request will be ignored
+                         session.fold(headers.get(HeaderNames.authorisation))(_.get(SessionKeys.authToken))
+                           .map(Authorization),
       forwarded        = forwardedFor(headers),
-      sessionId        = getSessionId(session, headers).map(SessionId),
+      sessionId        = session.flatMap(_.get(SessionKeys.sessionId))
+                           .orElse(headers.get(HeaderNames.xSessionId))
+                           .map(SessionId),
       requestId        = headers.get(HeaderNames.xRequestId).map(RequestId),
       requestChain     = buildRequestChain(headers.get(HeaderNames.xRequestChain)),
       nsStamp          = requestTimestamp(headers),
@@ -109,17 +83,20 @@ trait HeaderCarrierConverter {
       trueClientPort   = headers.get(HeaderNames.trueClientPort),
       gaToken          = headers.get(HeaderNames.googleAnalyticTokenId),
       gaUserId         = headers.get(HeaderNames.googleAnalyticUserId),
-      deviceID         = getDeviceId(cookies, headers),
+      deviceID         = session.fold(headers.get(HeaderNames.deviceID))(_ =>
+                           cookies.get(CookieNames.deviceID).map(_.value)
+                             .fold[Option[String]](headers.get(HeaderNames.deviceID))(Some(_))
+                         ),
       akamaiReputation = headers.get(HeaderNames.akamaiReputation).map(AkamaiReputation),
       otherHeaders     = otherHeaders(headers, request)
     )
+  }
 
   private def otherHeaders(headers: Headers, request: Option[RequestHeader]): Seq[(String, String)] =
     headers.headers
       .filterNot { case (k, _) => HeaderNames.explicitlyIncludedHeaders.map(_.toLowerCase).contains(k.toLowerCase) } ++
       // adding path so that play-auditing can access the request path without a dependency on play
       request.map(rh => Path -> rh.path).toSeq
-
 
   private def forwardedFor(headers: Headers): Option[ForwardedFor] =
     ((headers.get(HeaderNames.trueClientIp), headers.get(HeaderNames.xForwardedFor)) match {

--- a/http-verbs-play-25/src/test/scala/uk/gov/hmrc/http/HeadersSpec.scala
+++ b/http-verbs-play-25/src/test/scala/uk/gov/hmrc/http/HeadersSpec.scala
@@ -31,7 +31,6 @@ import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.WSClient
 import play.api.{Application, Play}
 import uk.gov.hmrc.http.hooks.HttpHook
-import uk.gov.hmrc.http.logging.{Authorization, ForwardedFor, RequestId, SessionId}
 import uk.gov.hmrc.play.http.ws.{PortTester, WSHttp}
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
+++ b/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
@@ -16,12 +16,14 @@
 
 package uk.gov.hmrc.play.connectors
 
+import com.github.ghik.silencer.silent
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.test.FakeApplication
 import play.api.test.Helpers._
 import uk.gov.hmrc.http._
 
+@silent("deprecated")
 class ConnectorSpec extends AnyWordSpecLike with Matchers {
   class TestConfig(val builderName: String, val builder: RequestBuilder, setupFunc: ((=> Any) => Any)) {
     def setup(f:                                                                      => Any) = setupFunc(f)

--- a/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
+++ b/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
@@ -21,7 +21,6 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.test.FakeApplication
 import play.api.test.Helpers._
 import uk.gov.hmrc.http._
-import uk.gov.hmrc.http.logging.{Authorization, ForwardedFor, RequestId, SessionId}
 
 class ConnectorSpec extends AnyWordSpecLike with Matchers {
   class TestConfig(val builderName: String, val builder: RequestBuilder, setupFunc: ((=> Any) => Any)) {

--- a/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
+++ b/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
@@ -112,8 +112,6 @@ class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers {
     }
   }
 
-  def headers(vals: (String, String)*) = FakeHeaders(vals.map { case (k, v) => k -> v })
-
   "Extracting the remaining header carrier values from the session and headers" should {
     "find nothing with a blank request" in {
       val hc = HeaderCarrierConverter.fromHeadersAndSession(FakeHeaders())
@@ -214,4 +212,6 @@ class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers {
         .deviceID shouldBe Some("deviceIdTest")
     }
   }
+
+  def headers(vals: (String, String)*) = FakeHeaders(vals.map { case (k, v) => k -> v })
 }

--- a/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
+++ b/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
@@ -22,7 +22,6 @@ import play.api.mvc.{Action, Controller, Cookie, Session}
 import play.api.test.Helpers._
 import play.api.test.{FakeApplication, FakeHeaders, FakeRequest}
 import uk.gov.hmrc.http._
-import uk.gov.hmrc.play.HeaderCarrierConverter
 
 import scala.concurrent.duration._
 

--- a/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
+++ b/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.play.http
 
+import com.github.ghik.silencer.silent
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.mvc.{Action, Controller, Cookie, Session}
@@ -25,6 +26,7 @@ import uk.gov.hmrc.http._
 
 import scala.concurrent.duration._
 
+@silent("deprecated")
 class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers {
 
   "Extracting the request timestamp from the session and headers" should {

--- a/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
+++ b/http-verbs-play-25/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
@@ -22,7 +22,6 @@ import play.api.mvc.{Action, Controller, Cookie, Session}
 import play.api.test.Helpers._
 import play.api.test.{FakeApplication, FakeHeaders, FakeRequest}
 import uk.gov.hmrc.http._
-import uk.gov.hmrc.http.logging._
 import uk.gov.hmrc.play.HeaderCarrierConverter
 
 import scala.concurrent.duration._

--- a/http-verbs-play-26/src/main/scala/uk/gov/hmrc/package.scala
+++ b/http-verbs-play-26/src/main/scala/uk/gov/hmrc/package.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc
+
+package play {
+
+  @deprecated("Use uk.gov.hmrc.play.http.HeaderCarrierConverter instead", "13.0.0")
+  object HeaderCarrierConverter extends uk.gov.hmrc.play.http.HeaderCarrierConverter
+}

--- a/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/HeaderCarrierConverter.scala
+++ b/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/HeaderCarrierConverter.scala
@@ -20,7 +20,6 @@ import com.typesafe.config.ConfigFactory
 import play.api.Configuration
 import play.api.mvc.{Cookies, Headers, RequestHeader, Session}
 import uk.gov.hmrc.http._
-import uk.gov.hmrc.http.logging._
 import play.api.http.{HeaderNames => PlayHeaderNames}
 
 import scala.util.Try

--- a/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/connectors/Connector.scala
+++ b/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/connectors/Connector.scala
@@ -19,10 +19,12 @@ package uk.gov.hmrc.play.connectors
 import play.api.libs.ws.{WSClient, WSRequest}
 import uk.gov.hmrc.http.HeaderCarrier
 
+@deprecated("Use uk.gov.hmrc.play.http.ws.WSRequestBuilder", "13.0.0")
 trait RequestBuilder {
   def buildRequest(url: String)(implicit hc: HeaderCarrier): WSRequest
 }
 
+@deprecated("Use uk.gov.hmrc.play.http.ws.WSRequest", "13.0.0")
 trait WSClientRequestBuilder extends RequestBuilder {
   def client: WSClient
   def buildRequest(url: String)(implicit hc: HeaderCarrier): WSRequest =

--- a/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/http/HeaderCarrierConverter.scala
+++ b/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/http/HeaderCarrierConverter.scala
@@ -14,34 +14,43 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.play
+package uk.gov.hmrc.play.http
 
-import com.github.ghik.silencer.silent
-import play.api.Play
+import com.typesafe.config.ConfigFactory
 import play.api.mvc.{Cookies, Headers, RequestHeader, Session}
 import uk.gov.hmrc.http._
+import play.api.http.{HeaderNames => PlayHeaderNames}
 
 import scala.util.Try
 
-object HeaderCarrierConverter {
+trait HeaderCarrierConverter {
 
-  def fromHeadersAndSession(headers: Headers, session: Option[Session] = None) =
+  def fromHeadersAndSession(headers: Headers, session: Option[Session] = None): HeaderCarrier =
     fromHeadersAndSessionAndRequest(headers, session, None)
 
-  def fromHeadersAndSessionAndRequest(headers: Headers, session: Option[Session] = None, request: Option[RequestHeader] = None) = {
-    lazy val cookies: Cookies = Cookies.fromCookieHeader(headers.get(play.api.http.HeaderNames.COOKIE))
-    session.fold(fromHeaders(headers, request)) {
-      fromSession(headers, cookies, request, _)
+  def fromHeadersAndSessionAndRequest(
+    headers: Headers,
+    session: Option[Session]       = None,
+    request: Option[RequestHeader] = None
+  ): HeaderCarrier =
+    session.fold(fromHeaders(headers, request)) { session =>
+      // Cookie setting changed between Play 2.5 and Play 2.6, this now checks both ways
+      // cookie can be set for backwards compatibility
+      val cookiesInHeader =
+        Cookies.fromCookieHeader(headers.get(PlayHeaderNames.COOKIE)).toList
+      val cookiesInSession =
+        request.map(_.cookies).map(_.toList).getOrElse(List.empty)
+      val cookies = Cookies(cookiesInSession ++ cookiesInHeader)
+      fromSession(headers, cookies, request, session)
     }
-  }
 
-  def buildRequestChain(currentChain: Option[String]): RequestChain =
+  private def buildRequestChain(currentChain: Option[String]): RequestChain =
     currentChain match {
       case None        => RequestChain.init
       case Some(chain) => RequestChain(chain).extend
     }
 
-  def requestTimestamp(headers: Headers): Long =
+  private def requestTimestamp(headers: Headers): Long =
     headers
       .get(HeaderNames.xRequestTimestamp)
       .flatMap(tsAsString => Try(tsAsString.toLong).toOption)
@@ -97,11 +106,9 @@ object HeaderCarrierConverter {
     )
 
   private def otherHeaders(headers: Headers, requestHeader: Option[RequestHeader]): Seq[(String, String)] =
-    headers.headers
-      .filterNot { case (k, _) => HeaderNames.explicitlyIncludedHeaders.map(_.toLowerCase).contains(k.toLowerCase) } ++
-      // adding path so that play-auditing can access the request path without a dependency on play
-      requestHeader.map(rh => Path -> rh.path).toSeq
-
+      headers.headers.filterNot { case (k, _) => HeaderNames.explicitlyIncludedHeaders.map(_.toLowerCase).contains(k.toLowerCase) } ++
+        // adding path so that play-auditing can access the request path without a dependency on play
+        requestHeader.map(rh => Path -> rh.path).toSeq
 
   private def forwardedFor(headers: Headers): Option[ForwardedFor] =
     ((headers.get(HeaderNames.trueClientIp), headers.get(HeaderNames.xForwardedFor)) match {
@@ -111,3 +118,5 @@ object HeaderCarrierConverter {
       case (Some(tcip), Some(xff))                         => Some(s"$tcip, $xff")
     }).map(ForwardedFor)
 }
+
+object HeaderCarrierConverter extends HeaderCarrierConverter

--- a/http-verbs-play-26/src/test/scala/uk/gov/hmrc/http/HeadersSpec.scala
+++ b/http-verbs-play-26/src/test/scala/uk/gov/hmrc/http/HeadersSpec.scala
@@ -31,7 +31,6 @@ import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.WSClient
 import play.api.{Application, Play}
 import uk.gov.hmrc.http.hooks.HttpHook
-import uk.gov.hmrc.http.logging.{Authorization, ForwardedFor, RequestId, SessionId}
 import uk.gov.hmrc.play.http.ws.{PortTester, WSHttp}
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
+++ b/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
@@ -16,12 +16,14 @@
 
 package uk.gov.hmrc.play.connectors
 
+import com.github.ghik.silencer.silent
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.WsTestClient
 import uk.gov.hmrc.http._
 
+@silent("deprecated")
 class ConnectorSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
   WsTestClient.withClient { wsClient =>
 

--- a/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
+++ b/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
@@ -22,8 +22,6 @@ import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.WsTestClient
 import uk.gov.hmrc.http._
 
-import uk.gov.hmrc.http.logging.{Authorization, ForwardedFor, RequestId, SessionId}
-
 class ConnectorSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
   WsTestClient.withClient { wsClient =>
 

--- a/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
+++ b/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
@@ -26,7 +26,6 @@ import play.api.test.Helpers._
 import play.api.test.{FakeHeaders, FakeRequest, FakeRequestFactory}
 import play.api.mvc.request.RequestFactory
 import uk.gov.hmrc.http._
-import uk.gov.hmrc.play.HeaderCarrierConverter
 
 import scala.concurrent.duration._
 

--- a/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
+++ b/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.play.http
 
+import com.github.ghik.silencer.silent
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -29,6 +30,7 @@ import uk.gov.hmrc.http._
 
 import scala.concurrent.duration._
 
+@silent("deprecated")
 class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll {
 
   "Extracting the request timestamp from the session and headers" should {

--- a/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
+++ b/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
@@ -308,7 +308,6 @@ class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers with Befo
           session = Session()
         )
         .otherHeaders.toSet should contain allElementsOf (Set(
-          "Host"       -> "localhost",
           "User-Agent" -> "quix",
           "quix"       -> "foo",
           "path"       -> "/"

--- a/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
+++ b/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
@@ -38,11 +38,25 @@ class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers with Befo
       HeaderCarrierConverter
         .fromHeadersAndSession(headers(HeaderNames.xRequestTimestamp -> "12345"), Some(Session()))
         .nsStamp shouldBe 12345
+
+      HeaderCarrierConverter
+        .fromRequestAndSession(
+          request = FakeRequest().withHeaders(HeaderNames.xRequestTimestamp -> "12345"),
+          session = Session()
+        )
+        .nsStamp shouldBe 12345
     }
 
     "ignore it in the header if present but not a valid Long" in {
       HeaderCarrierConverter
         .fromHeadersAndSession(headers(HeaderNames.xRequestTimestamp -> "13:14"), Some(Session()))
+        .nsStamp shouldBe System.nanoTime() +- 5.seconds.toNanos
+
+      HeaderCarrierConverter
+        .fromRequestAndSession(
+          request = FakeRequest().withHeaders(HeaderNames.xRequestTimestamp -> "13:14"),
+          session = Session()
+        )
         .nsStamp shouldBe System.nanoTime() +- 5.seconds.toNanos
     }
   }
@@ -51,6 +65,13 @@ class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers with Befo
     "copy it from the X-Forwarded-For header if there is no True-Client-IP header" in {
       HeaderCarrierConverter
         .fromHeadersAndSession(headers(HeaderNames.xForwardedFor -> "192.168.0.1"), Some(Session()))
+        .forwarded shouldBe Some(ForwardedFor("192.168.0.1"))
+
+      HeaderCarrierConverter
+        .fromRequestAndSession(
+          request = FakeRequest().withHeaders(HeaderNames.xForwardedFor -> "192.168.0.1"),
+          session = Session()
+        )
         .forwarded shouldBe Some(ForwardedFor("192.168.0.1"))
     }
 
@@ -63,6 +84,16 @@ class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers with Befo
           ),
           Some(Session()))
         .forwarded shouldBe Some(ForwardedFor("192.168.0.1"))
+
+      HeaderCarrierConverter
+        .fromRequestAndSession(
+          request = FakeRequest().withHeaders(
+                      HeaderNames.trueClientIp  -> "",
+                      HeaderNames.xForwardedFor -> "192.168.0.1"
+                    ),
+          session = Session()
+        )
+        .forwarded shouldBe Some(ForwardedFor("192.168.0.1"))
     }
 
     "be blank if the True-Client-IP header and the X-Forwarded-For header if both exist but are empty" in {
@@ -74,11 +105,28 @@ class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers with Befo
           ),
           Some(Session()))
         .forwarded shouldBe Some(ForwardedFor(""))
+
+      HeaderCarrierConverter
+        .fromRequestAndSession(
+          request = FakeRequest().withHeaders(
+                      HeaderNames.trueClientIp  -> "",
+                      HeaderNames.xForwardedFor -> ""
+                    ),
+          session = Session()
+        )
+        .forwarded shouldBe Some(ForwardedFor(""))
     }
 
     "copy it from the True-Client-IP header if there is no X-Forwarded-For header" in {
       HeaderCarrierConverter
         .fromHeadersAndSession(headers(HeaderNames.trueClientIp -> "192.168.0.1"), Some(Session()))
+        .forwarded shouldBe Some(ForwardedFor("192.168.0.1"))
+
+      HeaderCarrierConverter
+        .fromRequestAndSession(
+          request = FakeRequest().withHeaders(HeaderNames.trueClientIp -> "192.168.0.1"),
+          session = Session()
+        )
         .forwarded shouldBe Some(ForwardedFor("192.168.0.1"))
     }
 
@@ -91,6 +139,16 @@ class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers with Befo
           ),
           Some(Session()))
         .forwarded shouldBe Some(ForwardedFor("192.168.0.1, 192.168.0.2"))
+
+      HeaderCarrierConverter
+        .fromRequestAndSession(
+          request = FakeRequest().withHeaders(
+                      HeaderNames.trueClientIp  -> "192.168.0.1",
+                      HeaderNames.xForwardedFor -> "192.168.0.2"
+                    ),
+          session = Session()
+        )
+        .forwarded shouldBe Some(ForwardedFor("192.168.0.1, 192.168.0.2"))
     }
 
     "do not add the True-Client-IP header if it's already at the beginning of X-Forwarded-For" in {
@@ -101,6 +159,16 @@ class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers with Befo
             HeaderNames.xForwardedFor -> "192.168.0.1, 192.168.0.2"
           ),
           Some(Session()))
+        .forwarded shouldBe Some(ForwardedFor("192.168.0.1, 192.168.0.2"))
+
+      HeaderCarrierConverter
+        .fromRequestAndSession(
+          request = FakeRequest().withHeaders(
+                      HeaderNames.trueClientIp  -> "192.168.0.1",
+                      HeaderNames.xForwardedFor -> "192.168.0.1, 192.168.0.2"
+                    ),
+          session = Session()
+        )
         .forwarded shouldBe Some(ForwardedFor("192.168.0.1, 192.168.0.2"))
     }
 
@@ -113,20 +181,43 @@ class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers with Befo
           ),
           Some(Session()))
         .forwarded shouldBe Some(ForwardedFor("192.168.0.1, 192.168.0.2, 192.168.0.1"))
+
+      HeaderCarrierConverter
+        .fromRequestAndSession(
+          request = FakeRequest().withHeaders(
+                      HeaderNames.trueClientIp  -> "192.168.0.1",
+                      HeaderNames.xForwardedFor -> "192.168.0.2, 192.168.0.1"
+                    ),
+          session = Session()
+        )
+        .forwarded shouldBe Some(ForwardedFor("192.168.0.1, 192.168.0.2, 192.168.0.1"))
     }
   }
-
-  def headers(vals: (String, String)*) = FakeHeaders(vals.map { case (k, v) => k -> v })
 
   "Extracting the remaining header carrier values from the session and headers" should {
     "find nothing with a blank request" in {
       val hc = HeaderCarrierConverter.fromHeadersAndSession(FakeHeaders())
       hc.nsStamp shouldBe System.nanoTime() +- 5.seconds.toNanos
+
+      HeaderCarrierConverter
+        .fromRequest(FakeRequest())
+        .nsStamp shouldBe System.nanoTime() +- 5.seconds.toNanos
+
+      HeaderCarrierConverter
+        .fromRequestAndSession(FakeRequest(), Session())
+        .nsStamp shouldBe System.nanoTime() +- 5.seconds.toNanos
     }
 
     "find the authorization from the session" in {
       HeaderCarrierConverter
         .fromHeadersAndSession(headers(), Some(Session(Map(SessionKeys.authToken -> "let me in!"))))
+        .authorization shouldBe Some(Authorization("let me in!"))
+
+      HeaderCarrierConverter
+        .fromRequestAndSession(
+          request = FakeRequest(),
+          session = Session(Map(SessionKeys.authToken -> "let me in!"))
+        )
         .authorization shouldBe Some(Authorization("let me in!"))
     }
 
@@ -134,11 +225,25 @@ class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers with Befo
       HeaderCarrierConverter
         .fromHeadersAndSession(headers(HeaderNames.xRequestId -> "18476239874162"), Some(Session()))
         .requestId shouldBe Some(RequestId("18476239874162"))
+
+      HeaderCarrierConverter
+        .fromRequestAndSession(
+          request = FakeRequest().withHeaders(HeaderNames.xRequestId -> "18476239874162"),
+          session = Session()
+        )
+        .requestId shouldBe Some(RequestId("18476239874162"))
     }
 
     "find the sessionId from the session" in {
       HeaderCarrierConverter
         .fromHeadersAndSession(headers(), Some(Session(Map(SessionKeys.sessionId -> "sesssionIdFromSession"))))
+        .sessionId shouldBe Some(SessionId("sesssionIdFromSession"))
+
+      HeaderCarrierConverter
+        .fromRequestAndSession(
+          request = FakeRequest(),
+          session = Session(Map(SessionKeys.sessionId -> "sesssionIdFromSession"))
+        )
         .sessionId shouldBe Some(SessionId("sesssionIdFromSession"))
     }
 
@@ -146,10 +251,21 @@ class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers with Befo
       HeaderCarrierConverter
         .fromHeadersAndSession(headers(HeaderNames.xSessionId -> "sessionIdFromHeader"), Some(Session(Map.empty)))
         .sessionId shouldBe Some(SessionId("sessionIdFromHeader"))
+
+      HeaderCarrierConverter
+        .fromRequestAndSession(
+          request = FakeRequest().withHeaders(HeaderNames.xSessionId -> "sessionIdFromHeader"),
+          session = Session(Map.empty)
+        )
+        .sessionId shouldBe Some(SessionId("sessionIdFromHeader"))
     }
 
     "ignore the sessionId when it is not present in the headers nor session" in {
       HeaderCarrierConverter.fromHeadersAndSession(headers(), Some(Session(Map.empty))).sessionId shouldBe None
+
+      HeaderCarrierConverter
+        .fromRequestAndSession(FakeRequest(), Session())
+        .sessionId shouldBe None
     }
 
     "find the akamai reputation from the headers" in {
@@ -157,6 +273,13 @@ class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers with Befo
         .fromHeadersAndSession(
           headers(HeaderNames.akamaiReputation -> "ID=127.0.0.1;WEBATCK=7"),
           Some(Session())
+        )
+        .akamaiReputation shouldBe Some(AkamaiReputation("ID=127.0.0.1;WEBATCK=7"))
+
+      HeaderCarrierConverter
+        .fromRequestAndSession(
+          request = FakeRequest().withHeaders(HeaderNames.akamaiReputation -> "ID=127.0.0.1;WEBATCK=7"),
+          session = Session()
         )
         .akamaiReputation shouldBe Some(AkamaiReputation("ID=127.0.0.1;WEBATCK=7"))
     }
@@ -174,6 +297,36 @@ class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers with Befo
           "User-Agent" -> "quix",
           "quix"       -> "foo"
         )
+
+      HeaderCarrierConverter
+        .fromRequestAndSession(
+          request = FakeRequest().withHeaders(
+                      HeaderNames.xRequestId -> "18476239874162",
+                      "User-Agent"           -> "quix",
+                      "quix"                 -> "foo"
+                    ),
+          session = Session()
+        )
+        .otherHeaders.toSet should contain allElementsOf (Set(
+          "Host"       -> "localhost",
+          "User-Agent" -> "quix",
+          "quix"       -> "foo",
+          "path"       -> "/"
+        ))
+
+      HeaderCarrierConverter
+        .fromRequest(
+          request = FakeRequest().withHeaders(
+                      HeaderNames.xRequestId -> "18476239874162",
+                      "User-Agent"           -> "quix",
+                      "quix"                 -> "foo"
+                    )
+        )
+        .otherHeaders.toSet should contain allElementsOf (Set(
+          "User-Agent" -> "quix",
+          "quix"       -> "foo",
+          "path"       -> "/"
+        ))
     }
 
     "add the request path" in {
@@ -183,19 +336,46 @@ class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers with Befo
           request = Some(FakeRequest(GET, path = "/the/request/path"))
         )
         .otherHeaders shouldBe Seq("path" -> "/the/request/path")
+
+      HeaderCarrierConverter
+        .fromRequestAndSession(
+          request = FakeRequest(GET, path = "/the/request/path"),
+          session = Session()
+        )
+        .otherHeaders should contain ("path" -> "/the/request/path")
+
+      HeaderCarrierConverter
+        .fromRequest(
+          request = FakeRequest(GET, path = "/the/request/path")
+        )
+        .otherHeaders should contain ("path" -> "/the/request/path")
     }
   }
 
   "build Google Analytics headers from request" should {
     "find the GA user id and token" in {
-      val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(
-        headers(
-          HeaderNames.googleAnalyticTokenId -> "ga-token",
-          HeaderNames.googleAnalyticUserId  -> "123.456"
+      {
+        val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(
+          headers(
+            HeaderNames.googleAnalyticTokenId -> "ga-token",
+            HeaderNames.googleAnalyticUserId  -> "123.456"
+          )
         )
-      )
-      hc.gaToken  shouldBe Some("ga-token")
-      hc.gaUserId shouldBe Some("123.456")
+        hc.gaToken  shouldBe Some("ga-token")
+        hc.gaUserId shouldBe Some("123.456")
+      }
+
+      {
+        val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(
+          request = FakeRequest().withHeaders(
+                      HeaderNames.googleAnalyticTokenId -> "ga-token",
+                      HeaderNames.googleAnalyticUserId  -> "123.456"
+                    ),
+          session = Session()
+        )
+        hc.gaToken  shouldBe Some("ga-token")
+        hc.gaUserId shouldBe Some("123.456")
+      }
     }
   }
 
@@ -230,6 +410,8 @@ class HeaderCarrierConverterSpec extends AnyWordSpecLike with Matchers with Befo
         .deviceID shouldBe Some("deviceIdTest")
     }
   }
+
+  def headers(vals: (String, String)*) = FakeHeaders(vals.map { case (k, v) => k -> v })
 
   lazy val fakeApplication =
     GuiceApplicationBuilder(configuration = Configuration("play.allowGlobalApplication" -> true)).build()

--- a/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
+++ b/http-verbs-play-26/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierConverterSpec.scala
@@ -26,7 +26,6 @@ import play.api.test.Helpers._
 import play.api.test.{FakeHeaders, FakeRequest, FakeRequestFactory}
 import play.api.mvc.request.RequestFactory
 import uk.gov.hmrc.http._
-import uk.gov.hmrc.http.logging._
 import uk.gov.hmrc.play.HeaderCarrierConverter
 
 import scala.concurrent.duration._


### PR DESCRIPTION
- Moves headers case classes from `uk.gov.hmrc.http.logging` to `uk.gov.hmrc.http`. No type aliases have been created since clients typically import `http.logging._` and `http._` resulting in ambiguity.
- Moves `HeaderCarrerConverter` from `uk.gov.hmrc.play` to `uk.gov.hmrc.play.http` (with alias)
- Deprecates `HeaderCarrierConverter.fromHeadersAndSession` and `HeaderCarrierConverter.fromHeadersAndSessionAndRequest`, and added `HeaderCarrierConverter.fromRequest` and `HeaderCarrierConverter.fromRequestAndSession` instead, which have less parameter permutations, and easier to discover/document.
- Deprecates package `uk.gov.hmrc.play.connectors`