### PR TITLE
Bdog 1119 audit extra headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The Headers `Authorization`, `ForwardedFor`, `RequestChain`, `RequestId`, `Sessi
 
 ##### External hosts
 
-Explicit headers (those modelled explicitly in the `HeaderCarrier`) are no longer forwarded to external hosts. They will have to be provided explicitly via the *VERB* methods (GET, POST etc.).
+Explicit headers (those modelled explicitly in the `HeaderCarrier`) are no longer forwarded to external hosts. They should be provided explicitly via the *VERB* methods (GET, POST etc.).
 You can look them up from the headerCarrier by name. E.g. to forward Authorization and X-Request-Id header (case insensitive):
 ```scala
 client.GET("https://externalhost/api", headers = hc.headers("Authorization", "X-Request-Id"))
@@ -137,7 +137,7 @@ HeaderCarrier()
 
 Internal hosts are identified with the configuration `internalServiceHostPatterns`.
 The headers which are forwarded include all the headers modelled explicitly in the `HeaderCarrier`, plus any that are listed with the configuration `bootstrap.http.headersAllowlist`.
-For external hosts, the headers must be provided explicitly to the VERB function (`GET`, `POST` etc).
+For external hosts, the headers should be provided explicitly to the VERB function (`GET`, `POST` etc).
 
 When providing additional headers to http requests, if it corresponds to an explicit one on the HeaderCarrier, it is recommended to replace it, otherwise you will be sending it twice:
 ```scala

--- a/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HeaderCarrier.scala
+++ b/http-verbs-common/src/main/scala/uk/gov/hmrc/http/HeaderCarrier.scala
@@ -63,11 +63,7 @@ case class HeaderCarrier(
       HeaderNames.akamaiReputation      -> akamaiReputation.map(_.value)
     ).collect { case (k, Some(v)) => (k, v) }
 
-  @deprecated("Provide extra headers to VERB (GET, POST) functions", "13.0.0")
   def withExtraHeaders(headers: (String, String)*): HeaderCarrier =
-    this.copy(extraHeaders = extraHeaders ++ headers)
-
-  def addExtraHeaders(headers: Seq[(String, String)]): HeaderCarrier =
     this.copy(extraHeaders = extraHeaders ++ headers)
 
   def headers(names: Seq[String]): Seq[(String, String)] =

--- a/http-verbs-common/src/main/scala/uk/gov/hmrc/http/logging/LoggingDetails.scala
+++ b/http-verbs-common/src/main/scala/uk/gov/hmrc/http/logging/LoggingDetails.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.http.logging
 
-import scala.util.Random
 import uk.gov.hmrc.http.{Authorization, ForwardedFor, HeaderNames, RequestChain, RequestId, SessionId}
 
 trait LoggingDetails {

--- a/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/http/ws/WSRequest.scala
+++ b/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/http/ws/WSRequest.scala
@@ -39,7 +39,7 @@ trait WSRequest extends WSRequestBuilder {
   ): PlayWSRequest =
     wsClient.url(url)
       .withHeaders(
-        hc.addExtraHeaders(headers)
+        hc.withExtraHeaders(headers: _*)
           .headersForUrl(hcConfig)(url): _*
       )
 }

--- a/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/http/ws/WSRequest.scala
+++ b/http-verbs-play-25/src/main/scala/uk/gov/hmrc/play/http/ws/WSRequest.scala
@@ -18,13 +18,10 @@ package uk.gov.hmrc.play.http.ws
 
 import com.github.ghik.silencer.silent
 import play.api.libs.ws.{DefaultWSProxyServer, WSClient, WSProxyServer, WSRequest => PlayWSRequest }
-import play.api.{Configuration, Play, Logger}
+import play.api.{Configuration, Play}
 import uk.gov.hmrc.http.HeaderCarrier
 
 trait WSRequest extends WSRequestBuilder {
-
-  private val logger = Logger(getClass)
-
   import play.api.libs.ws.WS
 
   @silent("deprecated")
@@ -39,16 +36,12 @@ trait WSRequest extends WSRequestBuilder {
     headers: Seq[(String, String)]
   )(implicit
     hc: HeaderCarrier
-  ): PlayWSRequest = {
-    val hdrs = hc.headersForUrl(hcConfig)(url) ++ headers
-
-    val duplicates = hdrs.groupBy(_._1).filter(_._2.length > 1).map(_._1)
-    if (duplicates.nonEmpty)
-      logger.warn(s"The following headers were detected multiple times: ${duplicates.mkString(",")}")
-
+  ): PlayWSRequest =
     wsClient.url(url)
-      .withHeaders(hdrs: _*)
-  }
+      .withHeaders(
+        hc.addExtraHeaders(headers)
+          .headersForUrl(hcConfig)(url): _*
+      )
 }
 
 trait WSProxy extends WSRequest {

--- a/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/http/HeaderCarrierConverter.scala
+++ b/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/http/HeaderCarrierConverter.scala
@@ -103,11 +103,13 @@ trait HeaderCarrierConverter {
     )
   }
 
-  private def otherHeaders(headers: Headers, request: Option[RequestHeader]): Seq[(String, String)] =
-      headers.headers
-        .filterNot { case (k, _) => HeaderNames.explicitlyIncludedHeaders.map(_.toLowerCase).contains(k.toLowerCase) } ++
-        // adding path so that play-auditing can access the request path without a dependency on play
-        request.map(rh => Path -> rh.path).toSeq
+  private def otherHeaders(headers: Headers, request: Option[RequestHeader]): Seq[(String, String)] = {
+    val explicitlyIncludedHeadersLc = HeaderNames.explicitlyIncludedHeaders.map(_.toLowerCase)
+    headers.headers
+      .filterNot { case (k, _) => explicitlyIncludedHeadersLc.contains(k.toLowerCase) } ++
+      // adding path so that play-auditing can access the request path without a dependency on play
+      request.map(rh => Path -> rh.path).toSeq
+  }
 
   private def forwardedFor(headers: Headers): Option[ForwardedFor] =
     ((headers.get(HeaderNames.trueClientIp), headers.get(HeaderNames.xForwardedFor)) match {

--- a/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/http/ws/WSRequest.scala
+++ b/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/http/ws/WSRequest.scala
@@ -32,7 +32,7 @@ trait WSRequest extends WSRequestBuilder {
   ): PlayWSRequest =
     wsClient.url(url)
       .withHttpHeaders(
-        hc.addExtraHeaders(headers)
+        hc.withExtraHeaders(headers: _*)
           .headersForUrl(hcConfig)(url): _*
       )
 }

--- a/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/http/ws/WSRequest.scala
+++ b/http-verbs-play-26/src/main/scala/uk/gov/hmrc/play/http/ws/WSRequest.scala
@@ -16,14 +16,11 @@
 
 package uk.gov.hmrc.play.http.ws
 
-import play.api.{Configuration, Logger}
+import play.api.Configuration
 import play.api.libs.ws.{DefaultWSProxyServer, WSProxyServer, WSRequest => PlayWSRequest}
 import uk.gov.hmrc.http.HeaderCarrier
 
 trait WSRequest extends WSRequestBuilder {
-
-  private val logger = Logger(getClass)
-
   private lazy val hcConfig =
     HeaderCarrier.Config.fromConfig(configuration)
 
@@ -32,16 +29,12 @@ trait WSRequest extends WSRequestBuilder {
     headers: Seq[(String, String)]
   )(implicit
     hc: HeaderCarrier
-  ): PlayWSRequest = {
-    val hdrs = hc.headersForUrl(hcConfig)(url) ++ headers
-
-    val duplicates = hdrs.groupBy(_._1).filter(_._2.length > 1).map(_._1)
-    if (duplicates.nonEmpty)
-      logger.warn(s"The following headers were detected multiple times: ${duplicates.mkString(",")}")
-
+  ): PlayWSRequest =
     wsClient.url(url)
-      .withHttpHeaders(hdrs: _*)
-  }
+      .withHttpHeaders(
+        hc.addExtraHeaders(headers)
+          .headersForUrl(hcConfig)(url): _*
+      )
 }
 
 trait WSProxy extends WSRequest {


### PR DESCRIPTION
Extra headers passed directly to the VERB functions, rather than modifying the HeaderCarrier, are not audited. This PR ensures the treatment of extra headers is the same however they are provided.