### PR TITLE
BDOG-1378 Deprecate MdcLoggingExecutionContext and fix mdc in Retries

### DIFF
--- a/http-verbs-common/src/main/scala/uk/gov/hmrc/play/http/logging/Mdc.scala
+++ b/http-verbs-common/src/main/scala/uk/gov/hmrc/play/http/logging/Mdc.scala
@@ -30,17 +30,16 @@ object Mdc {
     block.map { a =>
       putMdc(mdcData)
       a
-    }.recover {
+    }.recoverWith {
       case t =>
         putMdc(mdcData)
-        throw t
+        Future.failed(t)
     }
 
-  private def putMdc(mdc: Map[String, String]): Unit = {
+  def putMdc(mdc: Map[String, String]): Unit =
     mdc.foreach {
       case (k, v) => MDC.put(k, v)
     }
-  }
 
   /** Restores MDC data to the continuation of a block, which may be discarding MDC data (e.g. uses a different execution context)
     */

--- a/http-verbs-common/src/main/scala/uk/gov/hmrc/play/http/logging/MdcLoggingExecutionContext.scala
+++ b/http-verbs-common/src/main/scala/uk/gov/hmrc/play/http/logging/MdcLoggingExecutionContext.scala
@@ -20,6 +20,7 @@ import org.slf4j.MDC
 
 import scala.concurrent.ExecutionContext
 
+@deprecated("MdcLoggingExecutionContext no longer required, please inject Play's default EC instead", "15.6.0")
 class MdcLoggingExecutionContext(wrapped: ExecutionContext, mdcData: Map[String, String])
   extends ExecutionContext {
 

--- a/http-verbs-common/src/test/scala/uk/gov/hmrc/play/http/logging/MdcLoggingExecutionContextSpec.scala
+++ b/http-verbs-common/src/test/scala/uk/gov/hmrc/play/http/logging/MdcLoggingExecutionContextSpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.play.http.logging
 
 import java.util.concurrent.{CountDownLatch, Executors}
 
+import com.github.ghik.silencer.silent
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.{Level, Logger => LogbackLogger}
 import ch.qos.logback.core.AppenderBase
@@ -33,6 +34,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.reflect._
 
+@silent("deprecated")
 class MdcLoggingExecutionContextSpec
     extends AnyWordSpecLike
     with Matchers


### PR DESCRIPTION
We don't use `MdcLoggingExecutionContext` anymore, it has been deprecated (as was the companion object previously).
It actually made a Retries assertion pass, which fails with the actual MDC implementation as used in bootstrap. The test has been updated to use the clone of the bootstrap implementation, and fixes Retries for this.