### PR TITLE
Update README to clarify the library default http-verbs.proxy.enabled…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ See [README](/README.md) for details.
 
 There are some differences with `WSProxyConfiguration.buildWsProxyServer`:
   * configPrefix is fixed to `proxy`.
-  * `proxy.proxyRequiredForThisEnvironment` has been replaced with `http-verbs.proxy.enabled`, but note, it defaults to false (rather than true). This is appropriate for development and tests, but will need explicitly enabling when deployed.
+  * `proxy.proxyRequiredForThisEnvironment` has been replaced with `http-verbs.proxy.enabled`, but note, it defaults to `false` (rather than `true`). This is appropriate for local development and tests, but will need enabling when deployed (if not already enabled by environmental configuration).
 
 
 ## Version 13.12.0

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ With `HttpClient`, to use a proxy requires creating a new instance of HttpClient
 httpClientV2.get(url"$url").withProxy.execute[ResponseType]
 ```
 
-* It uses `WSProxyConfiguration.buildWsProxyServer` which needs enabling with `http-verbs.proxy.enabled` in configuration, which by default is `false`, for development. See [WSProxyConfiguration](CHANGELOG.md#wsproxyconfiguration) for configuration changes.
+* It uses `WSProxyConfiguration.buildWsProxyServer` which is enabled with `http-verbs.proxy.enabled` in configuration. It is disabled by default, which is appropriate for local development and tests, but will need enabling when deployed (if not already enabled by environmental configuration).
 
 #### Streaming
 


### PR DESCRIPTION
… may have been overridden